### PR TITLE
feat: viewer setting ui

### DIFF
--- a/src/app/(default)/online/games/[game_id]/config/_components/Config/Config.tsx
+++ b/src/app/(default)/online/games/[game_id]/config/_components/Config/Config.tsx
@@ -97,6 +97,7 @@ const Config: React.FC<ConfigProps> = ({ user, game, players }) => {
               gameName={game.name}
               ruleType={game.ruleType}
               discordWebhookUrl={game.discordWebhookUrl || ""}
+              isPublic={game.isPublic || false}
             />
           </Tabs.Panel>
         </Box>

--- a/src/app/(default)/online/games/[game_id]/config/_components/OtherConfig.tsx
+++ b/src/app/(default)/online/games/[game_id]/config/_components/OtherConfig.tsx
@@ -8,6 +8,7 @@ import ConfigInput from "./ConfigInput";
 import CopyGame from "./CopyGame";
 import DeleteGame from "./DeleteGame";
 import ExportGame from "./ExportGame";
+import PublicityToggle from "./PublicityToggle";
 import SelectQuizset from "./SelectQuizset";
 
 import type { RuleNames } from "@/models/games";
@@ -19,6 +20,7 @@ type Props = {
   gameName: string;
   ruleType: RuleNames;
   discordWebhookUrl: string;
+  isPublic?: boolean;
 };
 
 /**
@@ -30,6 +32,7 @@ const OtherConfig: React.FC<Props> = ({
   gameName,
   ruleType,
   discordWebhookUrl,
+  isPublic = false,
 }) => {
   const [quizsets, setQuizsets] = useState<string[]>([]);
 
@@ -65,6 +68,14 @@ const OtherConfig: React.FC<Props> = ({
         game_id={gameId}
         game_quiz={undefined}
         quizset_names={quizsets}
+      />
+      <Title order={3} mt="xl">
+        公開設定
+      </Title>
+      <PublicityToggle
+        gameId={gameId}
+        isPublic={isPublic}
+        gameName={gameName}
       />
       <Title order={3} mt="xl">
         オプション

--- a/src/app/(default)/online/games/[game_id]/config/_components/PublicityToggle.tsx
+++ b/src/app/(default)/online/games/[game_id]/config/_components/PublicityToggle.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useTransition, useState } from "react";
+
+import {
+  Switch,
+  Text,
+  Group,
+  Alert,
+  Modal,
+  Button,
+  List,
+  ThemeIcon,
+} from "@mantine/core";
+import {
+  IconGlobe,
+  IconInfoCircle,
+  IconExclamationCircle,
+  IconEye,
+  IconUsers,
+  IconLock,
+} from "@tabler/icons-react";
+import { parseResponse } from "hono/client";
+
+import createApiClient from "@/utils/hono/browser";
+
+type PublicityToggleProps = {
+  gameId: string;
+  isPublic: boolean;
+  gameName: string;
+};
+
+/**
+ * ゲーム公開/非公開切り替えトグルコンポーネント
+ */
+const PublicityToggle: React.FC<PublicityToggleProps> = ({
+  gameId,
+  isPublic,
+  gameName,
+}) => {
+  const [isPending, startTransition] = useTransition();
+  const [confirmModalOpened, setConfirmModalOpened] = useState(false);
+  const [pendingValue, setPendingValue] = useState<boolean | null>(null);
+
+  /**
+   * トグル切り替えハンドラー（確認モーダルを表示）
+   */
+  const handleToggle = (newValue: boolean) => {
+    setPendingValue(newValue);
+    setConfirmModalOpened(true);
+  };
+
+  /**
+   * 実際の公開設定更新処理
+   */
+  const confirmToggle = () => {
+    if (pendingValue === null) return;
+
+    startTransition(async () => {
+      try {
+        const apiClient = createApiClient();
+        const result = await parseResponse(
+          apiClient.games[":gameId"].$patch({
+            param: { gameId },
+            json: { key: "isPublic", value: pendingValue },
+          })
+        );
+
+        if ("result" in result) {
+          setConfirmModalOpened(false);
+          setPendingValue(null);
+        } else {
+          console.error("公開設定の更新に失敗しました:", result.error);
+        }
+      } catch (error) {
+        console.error("公開設定の更新でエラーが発生しました:", error);
+      }
+    });
+  };
+
+  /**
+   * 確認モーダルをキャンセル
+   */
+  const cancelToggle = () => {
+    setConfirmModalOpened(false);
+    setPendingValue(null);
+  };
+
+  return (
+    <>
+      <Group justify="space-between" mb="md">
+        <div>
+          <Text fw={500} size="sm">
+            ゲームを公開
+          </Text>
+          <Text size="xs" c="dimmed">
+            認証なしで誰でも観戦できるようになります
+          </Text>
+        </div>
+        <Switch
+          checked={isPublic}
+          onChange={(event) => handleToggle(event.currentTarget.checked)}
+          disabled={isPending}
+          size="md"
+          thumbIcon={
+            isPublic ? (
+              <IconGlobe size={14} />
+            ) : (
+              <div style={{ width: 14, height: 14 }} />
+            )
+          }
+        />
+      </Group>
+
+      {isPublic && (
+        <Alert variant="light" color="blue" icon={<IconInfoCircle />} mb="md">
+          <Text size="sm">
+            「{gameName}
+            」は現在公開中です。Viewer専用URLから認証なしで観戦できます。
+            プレイヤー情報と進行状況がリアルタイムで公開されます。
+          </Text>
+        </Alert>
+      )}
+
+      {/* 確認モーダル */}
+      <Modal
+        opened={confirmModalOpened}
+        onClose={cancelToggle}
+        title={
+          <Group gap="xs">
+            <ThemeIcon color={pendingValue ? "orange" : "blue"} variant="light">
+              <IconExclamationCircle size={16} />
+            </ThemeIcon>
+            <Text fw={500}>
+              {pendingValue
+                ? "ゲームを公開しますか？"
+                : "ゲームを非公開にしますか？"}
+            </Text>
+          </Group>
+        }
+        size="md"
+      >
+        {pendingValue ? (
+          <>
+            <Alert
+              variant="light"
+              color="orange"
+              icon={<IconExclamationCircle />}
+              mb="md"
+            >
+              <Text size="sm" fw={500} mb="xs">
+                以下の内容が公開されます：
+              </Text>
+              <List size="sm" spacing="xs">
+                <List.Item
+                  icon={
+                    <ThemeIcon color="orange" size={18} radius="xl">
+                      <IconEye size={12} />
+                    </ThemeIcon>
+                  }
+                >
+                  ゲーム名とクイズ形式
+                </List.Item>
+                <List.Item
+                  icon={
+                    <ThemeIcon color="orange" size={18} radius="xl">
+                      <IconUsers size={12} />
+                    </ThemeIcon>
+                  }
+                >
+                  参加プレイヤーの名前・所属・スコア
+                </List.Item>
+                <List.Item
+                  icon={
+                    <ThemeIcon color="orange" size={18} radius="xl">
+                      <IconGlobe size={12} />
+                    </ThemeIcon>
+                  }
+                >
+                  進行状況とリアルタイム更新
+                </List.Item>
+              </List>
+            </Alert>
+            <Text size="sm" c="dimmed" mb="lg">
+              この操作により、Viewer専用URLが有効になり、認証なしで誰でもゲームを観戦できるようになります。
+            </Text>
+          </>
+        ) : (
+          <>
+            <Alert variant="light" color="blue" icon={<IconLock />} mb="md">
+              <Text size="sm">
+                ゲームが非公開になります。観戦者はアクセスできなくなり、
+                シェアされたViewer URLも無効になります。
+              </Text>
+            </Alert>
+          </>
+        )}
+
+        <Group justify="flex-end" gap="sm">
+          <Button variant="subtle" onClick={cancelToggle} disabled={isPending}>
+            キャンセル
+          </Button>
+          <Button
+            color={pendingValue ? "orange" : "blue"}
+            onClick={confirmToggle}
+            loading={isPending}
+          >
+            {pendingValue ? "公開する" : "非公開にする"}
+          </Button>
+        </Group>
+      </Modal>
+    </>
+  );
+};
+
+export default PublicityToggle;

--- a/src/app/(default)/online/games/_components/GameList/GameList.tsx
+++ b/src/app/(default)/online/games/_components/GameList/GameList.tsx
@@ -18,6 +18,7 @@ type Game = {
   updatedAt: string;
   logCount: number;
   playerCount: number;
+  isPublic: boolean;
 };
 
 type GameListProps = {

--- a/src/app/(default)/online/games/_components/GameListGrid/GameListGrid.tsx
+++ b/src/app/(default)/online/games/_components/GameListGrid/GameListGrid.tsx
@@ -4,6 +4,9 @@ import { Box, Card, Flex, List } from "@mantine/core";
 import { IconAdjustmentsHorizontal, IconPlayerPlay } from "@tabler/icons-react";
 import { cdate } from "cdate";
 
+import PublicityBadge from "../PublicityBadge/PublicityBadge";
+import ShareGameButton from "../ShareGameButton/ShareGameButton";
+
 import classes from "./GameListGrid.module.css";
 
 import ButtonLink from "@/app/_components/ButtonLink";
@@ -17,6 +20,7 @@ type GameListGridProps = {
     playerCount: number;
     logCount: number;
     updatedAt: string;
+    isPublic: boolean;
   }[];
 };
 
@@ -47,16 +51,24 @@ const GameListGrid: React.FC<GameListGridProps> = ({ gameList }) => {
                 {game.name}
               </Card.Section>
               <Card.Section className={classes.game_description}>
-                <List>
-                  <List.Item>
+                <Flex justify="space-between" align="center" mb="xs">
+                  <div>
                     {game.ruleType} ／ {game.playerCount}人
-                  </List.Item>
+                  </div>
+                  <PublicityBadge isPublic={game.isPublic} size="xs" />
+                </Flex>
+                <List>
                   <List.Item>進行状況: {game.logCount}問目</List.Item>
                 </List>
               </Card.Section>
               <Flex className={classes.game_footer}>
                 <Box>{cdate(game.updatedAt).format("MM/DD HH:mm")}</Box>
                 <Flex gap="xs">
+                  <ShareGameButton
+                    gameId={game.id}
+                    isPublic={game.isPublic}
+                    size="sm"
+                  />
                   <ButtonLink
                     href={`/online/games/${game.id}/board`}
                     leftSection={<IconPlayerPlay />}

--- a/src/app/(default)/online/games/_components/GameListTable/GameListTable.tsx
+++ b/src/app/(default)/online/games/_components/GameListTable/GameListTable.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { Table } from "@mantine/core";
+import { Group, Table } from "@mantine/core";
 import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
 import { cdate } from "cdate";
+
+import PublicityBadge from "../PublicityBadge/PublicityBadge";
+import ShareGameButton from "../ShareGameButton/ShareGameButton";
 
 import ButtonLink from "@/app/_components/ButtonLink";
 import Link from "@/app/_components/Link";
@@ -15,6 +18,7 @@ type GameListTableProps = {
     playerCount: number;
     logCount: number;
     updatedAt: string;
+    isPublic: boolean;
   }[];
 };
 
@@ -36,6 +40,7 @@ const GameListTable: React.FC<GameListTableProps> = ({ gameList }) => {
                 <Table.Th>形式</Table.Th>
                 <Table.Th>プレイヤー数</Table.Th>
                 <Table.Th>進行状況</Table.Th>
+                <Table.Th>公開状態</Table.Th>
                 <Table.Th>最終更新日時</Table.Th>
                 <Table.Th></Table.Th>
               </Table.Tr>
@@ -48,16 +53,26 @@ const GameListTable: React.FC<GameListTableProps> = ({ gameList }) => {
                   <Table.Td>{game.playerCount}人</Table.Td>
                   <Table.Td>{game.logCount}問目</Table.Td>
                   <Table.Td>
+                    <PublicityBadge isPublic={game.isPublic} size="sm" />
+                  </Table.Td>
+                  <Table.Td>
                     {cdate(game.updatedAt).format("MM/DD HH:mm")}
                   </Table.Td>
                   <Table.Td>
-                    <ButtonLink
-                      href={`/online/games/${game.id}/config`}
-                      leftSection={<IconAdjustmentsHorizontal />}
-                      size="sm"
-                    >
-                      開く
-                    </ButtonLink>
+                    <Group gap="xs">
+                      <ShareGameButton
+                        gameId={game.id}
+                        isPublic={game.isPublic}
+                        size="xs"
+                      />
+                      <ButtonLink
+                        href={`/online/games/${game.id}/config`}
+                        leftSection={<IconAdjustmentsHorizontal />}
+                        size="sm"
+                      >
+                        開く
+                      </ButtonLink>
+                    </Group>
                   </Table.Td>
                 </Table.Tr>
               ))}

--- a/src/app/(default)/online/games/_components/PublicityBadge/PublicityBadge.tsx
+++ b/src/app/(default)/online/games/_components/PublicityBadge/PublicityBadge.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Badge } from "@mantine/core";
+import { IconGlobe, IconLock } from "@tabler/icons-react";
+
+type PublicityBadgeProps = {
+  isPublic: boolean;
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
+};
+
+/**
+ * ゲーム公開状態表示バッジコンポーネント
+ */
+const PublicityBadge: React.FC<PublicityBadgeProps> = ({
+  isPublic,
+  size = "sm",
+}) => {
+  if (isPublic) {
+    return (
+      <Badge
+        color="green"
+        variant="light"
+        size={size}
+        leftSection={<IconGlobe size={12} />}
+      >
+        公開中
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge
+      color="gray"
+      variant="light"
+      size={size}
+      leftSection={<IconLock size={12} />}
+    >
+      非公開
+    </Badge>
+  );
+};
+
+export default PublicityBadge;

--- a/src/app/(default)/online/games/_components/ShareGameButton/ShareGameButton.tsx
+++ b/src/app/(default)/online/games/_components/ShareGameButton/ShareGameButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button, CopyButton, Tooltip, rem } from "@mantine/core";
+import { IconCheck, IconShare } from "@tabler/icons-react";
+
+type ShareGameButtonProps = {
+  gameId: string;
+  isPublic: boolean;
+  size?: "xs" | "sm" | "md" | "lg" | "xl";
+  variant?: "filled" | "light" | "outline" | "subtle" | "default";
+};
+
+/**
+ * 公開ゲーム用シェアボタンコンポーネント
+ * Viewer専用URLを生成してコピー機能を提供
+ */
+const ShareGameButton: React.FC<ShareGameButtonProps> = ({
+  gameId,
+  isPublic,
+  size = "sm",
+  variant = "light",
+}) => {
+  const [tooltipOpened, setTooltipOpened] = useState(false);
+
+  if (!isPublic) {
+    return null;
+  }
+
+  const viewerUrl = `${window.location.origin}/viewer/games/${gameId}`;
+
+  return (
+    <CopyButton value={viewerUrl} timeout={2000}>
+      {({ copied, copy }) => (
+        <Tooltip
+          label={copied ? "コピーしました" : "Viewer URLをコピー"}
+          withArrow
+          position="top"
+          opened={tooltipOpened || copied}
+        >
+          <Button
+            color={copied ? "teal" : "blue"}
+            variant={variant}
+            size={size}
+            onClick={() => {
+              copy();
+              setTooltipOpened(false);
+            }}
+            leftSection={
+              copied ? (
+                <IconCheck style={{ width: rem(16) }} />
+              ) : (
+                <IconShare style={{ width: rem(16) }} />
+              )
+            }
+          >
+            {copied ? "コピー完了" : "シェア"}
+          </Button>
+        </Tooltip>
+      )}
+    </CopyButton>
+  );
+};
+
+export default ShareGameButton;

--- a/src/app/(default)/online/games/_components/ShareGameButton/ShareGameButton.tsx
+++ b/src/app/(default)/online/games/_components/ShareGameButton/ShareGameButton.tsx
@@ -29,7 +29,18 @@ const ShareGameButton: React.FC<ShareGameButtonProps> = ({
   }
 
   const viewerUrl = `${window.location.origin}/viewer/games/${gameId}`;
+  const [viewerUrl, setViewerUrl] = useState("");
 
+  // Set viewerUrl on client after mount
+  React.useEffect(() => {
+    if (typeof window !== "undefined") {
+      setViewerUrl(`${window.location.origin}/viewer/games/${gameId}`);
+    }
+  }, [gameId]);
+
+  if (!isPublic) {
+    return null;
+  }
   return (
     <CopyButton value={viewerUrl} timeout={2000}>
       {({ copied, copy }) => (

--- a/src/app/(default)/online/games/page.tsx
+++ b/src/app/(default)/online/games/page.tsx
@@ -30,7 +30,10 @@ const GamesPage = async () => {
     return "データ取得に失敗しました";
   }
 
-  const games = gamesData.games;
+  const games = gamesData.games.map((game) => ({
+    ...game,
+    isPublic: game.isPublic ?? false,
+  }));
 
   return <GameList games={games} />;
 };

--- a/src/server/repositories/game.ts
+++ b/src/server/repositories/game.ts
@@ -94,6 +94,7 @@ export const getGames = async (userId: string) => {
     name: game.name,
     ruleType: game.ruleType,
     updatedAt: game.updatedAt,
+    isPublic: game.isPublic,
     logCount: count(gameLog.id),
     playerCount: count(gamePlayer.id),
   })


### PR DESCRIPTION
close #111 

#  実装された機能

##  1. ゲーム設定画面の公開/非公開切り替え機能

  - PublicityToggle コンポーネントを作成
  - 確認モーダル付きの安全な切り替え機能
  - 公開時と非公開時の詳細な警告メッセージ
  - API連携によるリアルタイム更新

##  2. ゲーム一覧での公開状態表示

  - PublicityBadge コンポーネントを作成
  - グリッド表示とテーブル表示の両方に対応
  - 視覚的に分かりやすいアイコンと色分け

##  3. 公開ゲーム用シェア機能

  - ShareGameButton コンポーネントを作成
  - Viewer URL の自動生成とワンクリックコピー
  - 公開ゲームのみに表示される条件付きUI

##  4. データベース・API対応

  - ゲーム一覧APIのレスポンスにisPublicフィールドを追加
  - 既存のゲーム更新APIを活用した設定保存

##  5. UI/UX改善

  - 確認モーダルによる誤操作防止
  - 詳細な説明文による理解促進
  - レスポンシブ対応とアクセシビリティ配慮

#  変更されたファイル

  1. src/server/repositories/game.ts - ゲーム一覧API拡張
  2. src/app/(default)/online/games/page.tsx - データ変換追加
  3. src/app/(default)/online/games/[game_id]/config/_components/ -  新規コンポーネント追加
  4. src/app/(default)/online/games/_components/ - 一覧画面拡張