### PR TITLE
fix: アプリ設定トグルのlocalStorageキー名不一致を修正 (#131)

### DIFF
--- a/src/app/(board)/games/[game_id]/board/_components/WinModal/WinModal.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/WinModal/WinModal.tsx
@@ -12,8 +12,8 @@ type Props = {
 };
 
 const WinModal: React.FC<Props> = ({ onClose, winTroughPlayer }) => {
-  const showWinthroughPopup = useLocalStorage({
-    key: "scorew_show_winthrough_popup",
+  const [showWinthroughPopup] = useLocalStorage({
+    key: "showWinthroughPopup",
     defaultValue: true,
   });
   if (winTroughPlayer.name === "") return null;

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -57,8 +57,8 @@ export const createGame = async (
 };
 
 export const numberSign = (type: "correct" | "wrong" | "pt", score?: number) => {
-  const showSignString = localStorage.getItem("scorew-show-sign-string");
-  const wrongNumber = localStorage.getItem("scorew-wrong-number");
+  const showSignString = localStorage.getItem("showSignString");
+  const wrongNumber = localStorage.getItem("wrongNumber");
   if (typeof score === "undefined") {
     switch (type) {
       case "correct":


### PR DESCRIPTION
## 概要

Issue #131 で報告された、アプリ設定（`/option`）の以下3つのトグルが機能しない不具合を修正します。

- 勝ち抜け時にポップアップを表示
- スコアに「○」「✕」「pt」の文字列を付与する
- 誤答数が4以下のとき✕の数で表示

## 原因

設定値の保存側（`Preferences.tsx`、camelCase キー）と読み取り側（旧 `scorew-` プレフィックスキー）で localStorage のキー名が不一致になっており、トグルの値が読み取り側に反映されていませんでした。

加えて `WinModal.tsx` では `useLocalStorage` の戻り値を分割代入していなかったため、タプル（配列）が常に truthy となり、ポップアップが常に表示される状態でした。

## 変更内容

- `WinModal.tsx`: キー名を `showWinthroughPopup` に統一し、戻り値を分割代入に修正
- `functions.ts`（`numberSign`）: 読み取りキーを `showSignString` / `wrongNumber` に統一

## テスト計画

- [ ] `/option` で3トグルをそれぞれ OFF にし、ボード画面で挙動が反映されることを確認
  - [ ] 「○✕pt 文字列」OFF → スコアが数値のみ表示
  - [ ] 「誤答数✕表示」OFF → 誤答が `N✕` 表記
  - [ ] 「勝ち抜けポップアップ」OFF → 勝ち抜け時にモーダルが出ない
- [ ] 各トグルを ON に戻し、挙動が切り替わることを確認

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)