### PR TITLE
fix: 誤答数の記号表示で✕の個数と○混入のバグを修正 (#138)

### DIFF
--- a/src/app/(board)/games/[game_id]/board/_components/AQLPlayer/AQLPlayer.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/AQLPlayer/AQLPlayer.tsx
@@ -6,7 +6,7 @@ import { Flex, useComputedColorScheme } from "@mantine/core";
 import { useLiveQuery } from "dexie-react-hooks";
 
 import db from "@/utils/db";
-import { numberSign } from "@/utils/functions";
+import { useNumberSign } from "@/utils/useNumberSign";
 
 import PlayerHeader from "../PlayerHeader/PlayerHeader";
 import PlayerName from "../PlayerName/PlayerName";
@@ -32,6 +32,7 @@ const AQLPlayer: React.FC<Props> = ({
   is_incapacity,
   currentProfile,
 }) => {
+  const numberSign = useNumberSign();
   const computedColorScheme = useComputedColorScheme("light");
   const game = useLiveQuery(() => db(currentProfile).games.get(game_id as string));
   const [editableState, setEditableState] = useState<States>("playing");

--- a/src/app/(board)/games/[game_id]/board/_components/PlayerScore/PlayerScore.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/PlayerScore/PlayerScore.tsx
@@ -6,7 +6,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { nanoid } from "nanoid";
 
 import db from "@/utils/db";
-import { numberSign } from "@/utils/functions";
+import { useNumberSign } from "@/utils/useNumberSign";
 
 import PlayerScoreButton from "../PlayerScoreButton/PlayerScoreButton";
 import classes from "./PlayerScore.module.css";
@@ -20,6 +20,7 @@ type Props = {
 };
 
 const PlayerScore: React.FC<Props> = ({ game, player, currentProfile }) => {
+  const numberSign = useNumberSign();
   const logs = useLiveQuery(
     () => db(currentProfile).logs.where({ game_id: game.id, available: 1 }).sortBy("timestamp"),
     []

--- a/src/app/(board)/games/[game_id]/board/_components/PlayerScoreButton/PlayerScoreButton.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/PlayerScoreButton/PlayerScoreButton.tsx
@@ -43,6 +43,8 @@ const PlayerScoreButton: React.FC<Props> = ({
       : children.endsWith("✕")
         ? "wrong"
         : "none";
+  // 「数値 + 記号」の形式のときのみ記号部分を小さく表示し、連続記号はそのまま表示する。
+  const signParts = children.match(/^(-?\d+)((?:○)|(?:✕)|(?:pt))$/);
   const computedColorScheme = useComputedColorScheme("light");
 
   const defaultColor = computedColorScheme === "light" ? "white" : "gray.8";
@@ -128,12 +130,12 @@ const PlayerScoreButton: React.FC<Props> = ({
           c={filled ? defaultColor : variantColor}
           bg={filled ? variantColor : "transparent"}
         >
-          {numberSign === "none" ? (
+          {numberSign === "none" || signParts === null ? (
             <span>{children}</span>
           ) : (
             <>
-              <span>{children.split(/((?:○)|(?:✕)|(?:pt))/)[0]}</span>
-              <span style={{ fontSize: "50%" }}>{children.split(/((?:○)|(?:✕)|(?:pt))/)[1]}</span>
+              <span>{signParts[1]}</span>
+              <span style={{ fontSize: "50%" }}>{signParts[2]}</span>
             </>
           )}
         </UnstyledButton>

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -79,7 +79,7 @@ export const numberSign = (type: "correct" | "wrong" | "pt", score?: number) => 
           } else if (0 < score && score < 5) {
             return "✕".repeat(score);
           } else {
-            return `${score}○`;
+            return `${score}✕`;
           }
         } else {
           return `${score}✕`;
@@ -94,7 +94,7 @@ export const numberSign = (type: "correct" | "wrong" | "pt", score?: number) => 
       } else if (0 < score && score < 5) {
         return "✕".repeat(score);
       } else {
-        return `${score}○`;
+        return `${score}✕`;
       }
     } else {
       return score.toString();

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -94,7 +94,8 @@ export const numberSign = (type: "correct" | "wrong" | "pt", score?: number) => 
       } else if (0 < score && score < 5) {
         return "✕".repeat(score);
       } else {
-        return `${score}✕`;
+        // 記号付与がオフのため誤答数5以上は数値のみで表示する
+        return score.toString();
       }
     } else {
       return score.toString();

--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -56,9 +56,30 @@ export const createGame = async (
   }
 };
 
-export const numberSign = (type: "correct" | "wrong" | "pt", score?: number) => {
-  const showSignString = localStorage.getItem("showSignString");
-  const wrongNumber = localStorage.getItem("wrongNumber");
+/** numberSign の表示設定。未指定時は localStorage から読み取る */
+type NumberSignOptions = {
+  /** スコアに「○」「✕」「pt」の文字列を付与するか */
+  showSignString: boolean;
+  /** 誤答数が4以下のとき✕の数で表示するか */
+  wrongNumber: boolean;
+};
+
+/**
+ * スコアの表示文字列を生成する。
+ * options を渡すとその設定で計算し、省略時は localStorage から設定を読み取る（React 外のスコア計算用）。
+ * @param type スコアの種別
+ * @param score 表示する数値（未指定時は記号のみを返す）
+ * @param options 表示設定（React コンポーネントからリアクティブな値を渡す）
+ * @returns 表示用の文字列
+ */
+export const numberSign = (
+  type: "correct" | "wrong" | "pt",
+  score?: number,
+  options?: NumberSignOptions
+) => {
+  const showSignString =
+    options?.showSignString ?? localStorage.getItem("showSignString") !== "false";
+  const wrongNumber = options?.wrongNumber ?? localStorage.getItem("wrongNumber") === "true";
   if (typeof score === "undefined") {
     switch (type) {
       case "correct":
@@ -68,12 +89,12 @@ export const numberSign = (type: "correct" | "wrong" | "pt", score?: number) => 
       case "pt":
         return "pt";
     }
-  } else if (showSignString === "true" || showSignString === null) {
+  } else if (showSignString) {
     switch (type) {
       case "correct":
         return `${score}○`;
       case "wrong":
-        if (wrongNumber === "true") {
+        if (wrongNumber) {
           if (score === 0) {
             return "・";
           } else if (0 < score && score < 5) {
@@ -88,7 +109,7 @@ export const numberSign = (type: "correct" | "wrong" | "pt", score?: number) => 
         return `${score}pt`;
     }
   } else {
-    if (type === "wrong" && wrongNumber === "true") {
+    if (type === "wrong" && wrongNumber) {
       if (score === 0) {
         return "・";
       } else if (0 < score && score < 5) {

--- a/src/utils/useNumberSign.ts
+++ b/src/utils/useNumberSign.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useCallback } from "react";
+
+import { useLocalStorage } from "@mantine/hooks";
+
+import { numberSign } from "@/utils/functions";
+
+/**
+ * 表示設定（showSignString・wrongNumber）を購読し、現在の設定で束縛した numberSign を返すフック。
+ * 設定スイッチの変更が次の操作を待たずに即座に再描画へ反映される。
+ * @returns スコアの表示文字列を生成する関数
+ */
+export const useNumberSign = () => {
+  const [showSignString] = useLocalStorage({
+    key: "showSignString",
+    defaultValue: true,
+  });
+  const [wrongNumber] = useLocalStorage({
+    key: "wrongNumber",
+    defaultValue: true,
+  });
+
+  return useCallback(
+    (type: "correct" | "wrong" | "pt", score?: number) =>
+      numberSign(type, score, { showSignString, wrongNumber }),
+    [showSignString, wrongNumber]
+  );
+};

--- a/tests/game.spec.ts
+++ b/tests/game.spec.ts
@@ -137,3 +137,76 @@ test.describe("得点表示", () => {
     }
   });
 });
+
+test.describe("誤答数の記号表示", () => {
+  test.describe.configure({ mode: "default" });
+
+  test.beforeAll(async () => {
+    // 「誤答数が4以下のとき✕の数で表示」を有効化した状態で検証する
+    await page.addInitScript(() => {
+      window.localStorage.setItem("wrongNumber", "true");
+    });
+    // 初回表示でアップデートモーダルがバージョンを保存するため、reloadで閉じる
+    await page.goto("http://localhost:3000/");
+    await page.reload();
+  });
+
+  test("N○M✕形式のゲームを作成できる", async ({ isMobile }) => {
+    if (isMobile) {
+      await page.getByRole("banner").getByRole("button").first().click();
+    }
+    await page.getByRole("link", { name: "ゲームを作る" }).click();
+    await expect(page).toHaveTitle(/形式一覧/);
+    // 「N○M✕」(nomx)と「連答つきN○M✕」(nomx-ad)を区別するため厳密一致で絞り込む
+    const card = page
+      .locator('[class*="mantine-Card-root"]')
+      .filter({ has: page.getByText("N○M✕", { exact: true }) });
+    await card.getByRole("button", { name: "作る" }).click();
+    await expect(page).toHaveTitle(/ゲーム設定/);
+  });
+
+  test("失格誤答数を増やして敗退を防ぐ", async () => {
+    // 既定では誤答3回で失格になるため、表示検証のため失格誤答数を増やす
+    const losePointInput = page.getByLabel("失格誤答数");
+    await losePointInput.fill("10");
+    await expect(losePointInput).toHaveValue("10");
+  });
+
+  test("プレイヤーを作成してゲームを開始できる", async () => {
+    await page.getByRole("tab", { name: "プレイヤー設定" }).click();
+    await page.getByRole("button", { name: "プレイヤーを選択" }).click();
+    // ドロワーの「新しく追加」からプレイヤーを2人作成する
+    const dialog = page.getByRole("dialog");
+    for (let i = 1; i <= 2; i++) {
+      await dialog.getByLabel("氏名").fill(`誤答テスト${i}`);
+      await dialog.getByRole("button", { name: "追加する" }).click();
+      await page.getByRole("alert").getByRole("button").first().click();
+    }
+    await page.keyboard.press("Escape");
+    const startButton = page.getByRole("link", { name: "ゲーム開始" });
+    await expect(startButton).toBeVisible();
+    await startButton.click();
+    await expect(page).toHaveURL(/board/);
+  });
+
+  test("誤答数1〜3のとき✕が誤答数だけ表示される", async () => {
+    const wrongButton = page.getByTestId("player").first().getByRole("button").nth(1);
+    // 誤答数0のときは中黒で表示される
+    await expect(wrongButton).toHaveText("・");
+    await wrongButton.click();
+    await expect(wrongButton).toHaveText("✕");
+    await wrongButton.click();
+    await expect(wrongButton).toHaveText("✕✕");
+    await wrongButton.click();
+    await expect(wrongButton).toHaveText("✕✕✕");
+  });
+
+  test("誤答数が4を超えると数値表示になり○が付かない", async () => {
+    const wrongButton = page.getByTestId("player").first().getByRole("button").nth(1);
+    // 誤答数3の状態から5まで増やす
+    await wrongButton.click();
+    await wrongButton.click();
+    await expect(wrongButton).toContainText("5✕");
+    await expect(wrongButton).not.toContainText("○");
+  });
+});

--- a/tests/game.spec.ts
+++ b/tests/game.spec.ts
@@ -208,4 +208,15 @@ test.describe("誤答数の記号表示", () => {
     await expect(wrongButton).toContainText("5✕");
     await expect(wrongButton).not.toContainText("○");
   });
+
+  test("記号付与がオフのとき誤答数5以上は数値のみ表示される", async () => {
+    // 「スコアに○✕ptの文字列を付与する」をオフにして再読み込みする
+    await page.evaluate(() => window.localStorage.setItem("showSignString", "false"));
+    await page.reload();
+    // 直前のテストで誤答数は5になっている
+    const wrongButton = page.getByTestId("player").first().getByRole("button").nth(1);
+    await expect(wrongButton).toHaveText("5");
+    await expect(wrongButton).not.toContainText("✕");
+    await expect(wrongButton).not.toContainText("○");
+  });
 });

--- a/tests/game.spec.ts
+++ b/tests/game.spec.ts
@@ -7,8 +7,9 @@ let page: Page;
 let context: BrowserContext;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  // context.addInitScript を page に効かせるため、page は context から生成する
   context = await browser.newContext();
+  page = await context.newPage();
   await page.goto("http://localhost:3000/");
 });
 
@@ -31,9 +32,7 @@ test.describe("得点表示", () => {
   test.describe.configure({ mode: "default" });
 
   test.beforeAll(async () => {
-    await context.addInitScript(() => {
-      window.localStorage.setItem("scorewatcher-version", "latest");
-    });
+    // アップデートモーダルは「アップデートモーダル」テストで閉じ済みのため、再読み込みして開始する
     await page.reload();
   });
 
@@ -143,7 +142,7 @@ test.describe("誤答数の記号表示", () => {
 
   test.beforeAll(async () => {
     // 「誤答数が4以下のとき✕の数で表示」を有効化した状態で検証する
-    await page.addInitScript(() => {
+    await context.addInitScript(() => {
       window.localStorage.setItem("wrongNumber", "true");
     });
     // 初回表示でアップデートモーダルがバージョンを保存するため、reloadで閉じる

--- a/tests/game.spec.ts
+++ b/tests/game.spec.ts
@@ -219,4 +219,15 @@ test.describe("誤答数の記号表示", () => {
     await expect(wrongButton).not.toContainText("✕");
     await expect(wrongButton).not.toContainText("○");
   });
+
+  test("表示設定の切り替えがスコア操作なしで即座に反映される", async () => {
+    // 直前のテストで showSignString=false。誤答数0の2人目で wrongNumber の切り替えを検証する
+    const wrongButton = page.getByTestId("player").nth(1).getByRole("button").nth(1);
+    await expect(wrongButton).toHaveText("・");
+    // 「表示設定」ドロワーを開き、得点ボタンを押さずにスイッチを切り替える
+    await page.getByRole("button", { name: "表示設定" }).click();
+    await page.getByLabel("誤答数が4以下のとき✕の数で表示").click();
+    // 得点操作をしていないが、スイッチ変更で表示が即座に更新される
+    await expect(wrongButton).toHaveText("0");
+  });
 });


### PR DESCRIPTION
## 概要

Issue #138 の修正です。「誤答数が4以下のとき✕の数で表示」を有効化した際の表示バグを修正し、あわせて表示設定の即時反映とテストを整備しました。

## バグ内容

1. **誤答数1〜3で✕が1個しか表示されない**
   `PlayerScoreButton` が表示文字列を `split(/((?:○)|(?:✕)|(?:pt))/)` で分割し `[0]`・`[1]` だけを使用していたため、「✕✕✕」のように記号が連続するとインデックス1の1個分しか描画されていませんでした。

2. **誤答数が4を超えると「○」が付く**
   `numberSign` 関数が誤答数5以上のとき `${score}○` を返しており、設定の有効・無効にかかわらず誤って「○」が付与されていました。

3. **記号付与オフ時に誤答数5以上で✕が付く**
   「スコアに○✕ptの文字列を付与する」がオフのとき、誤答数5以上でも `${score}✕` を返していました。記号付与オフ時は数値のみにすべきです。

## 修正内容

- `src/utils/functions.ts`: 誤答数5以上の返り値を修正（記号付与オン→`${score}✕`、オフ→数値のみ）。あわせて設定をオプション引数で受け取れるようリファクタ（省略時は従来通り `localStorage` を読む）。
- `src/app/(board)/.../PlayerScoreButton.tsx`: 「数値+記号」の形式（`/^(-?\d+)(○|✕|pt)$/`）にマッチするときのみ記号部分を小さく表示し、連続記号はそのまま全体を表示するよう変更。

## 表示設定の即時反映

`numberSign` が `localStorage` を直接読んでいたため、表示設定スイッチ（showSignString・wrongNumber）の切り替えが**次のスコア操作まで反映されない**問題がありました。

- `src/utils/useNumberSign.ts`（新規）: 設定を `useLocalStorage` で購読し、現在の設定で束縛した `numberSign` を返すフックを追加。
- `PlayerScore.tsx` / `AQLPlayer.tsx`: このフックを使用し、設定変更が操作を待たず即座に再描画へ反映されるよう変更。
- `wrongNumber` 未設定時の既定値を Preferences スイッチの既定（ON）に揃え、設定UIと盤面表示の不整合を解消。

## テスト基盤の修正

既存の `context.addInitScript` が `browser.newPage()` 由来の `page` とは無関係な `browser.newContext()` に対して呼ばれており無効化されていたため、`page` を `context` から生成して紐付け、効果のないバージョン設定を除去しました。

## テスト

`tests/game.spec.ts` に「誤答数の記号表示」describe を追加（全7ケース）。

- 誤答数0=「・」、1〜3=✕の個数分、5=「5✕」かつ「○」が付かない
- 記号付与オフ時は誤答数5以上で数値のみ
- 表示設定スイッチの切り替えがスコア操作なしで即座に反映される

確認:
- `pnpm run playwright tests/game.spec.ts` → 19 passed
- `npx tsc --noEmit` / `pnpm run lint` 通過

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)