### PR TITLE
ci: Dependabot自動マージの導入とpnpmバージョン更新

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,22 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -69,5 +69,5 @@
   "engines": {
     "node": "24.x"
   },
-  "packageManager": "pnpm@11.2.2"
+  "packageManager": "pnpm@11.4.0"
 }


### PR DESCRIPTION
## 概要

[next-template](https://github.com/newt239/next-template) を参照し、Dependabotの運用を整備しました。

## 変更内容

### Auto Merge CI の導入
- `.github/workflows/dependabot-auto-merge.yml` を新規追加
- Dependabotが作成したPRに対し `gh pr merge --auto --merge` で自動マージを有効化
- `dependabot/fetch-metadata` でメタデータを取得

### Dependabot 設定（既存を確認）
既存の `.github/dependabot.yml` は以下を既に満たしているため変更不要でした。
- `npm` と `github-actions` の両エコシステムを対象
- それぞれ `groups` でグループ化（1PRにまとめる）
- monthly スケジュール（Asia/Tokyo）

### pnpm バージョン更新
- `package.json` の `packageManager` を `pnpm@11.2.2` → `pnpm@11.4.0`（最新）に更新
- CIの `pnpm/action-setup` はバージョン未指定で `packageManager` を参照するため追加変更は不要

## 補足

自動マージを実際に機能させるには、リポジトリ設定で **Allow auto-merge** を有効化する必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)