### PR TITLE
fix: ゲーム独自のプレイヤー名を表示し元データ編集ダイアログを追加 (#143)

### DIFF
--- a/src/app/(board)/games/[game_id]/board/_components/Board/Board.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/Board/Board.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Box } from "@mantine/core";
 import { useLocalStorage, useWindowEvent } from "@mantine/hooks";
@@ -48,8 +48,22 @@ const Board: React.FC<Props> = ({ game_id, current_profile }) => {
   );
   const [scores, setScores] = useState<ComputedScoreProps[]>([]);
   const playerList = useLiveQuery(() => db(currentProfile).players.toArray(), [currentProfile]);
-  const [players, setPlayers] = useState<PlayerDBProps[]>([]);
   const [skipSuggest, setSkipSuggest] = useState(false);
+
+  // 表示名はゲーム独自名(game.players[].name)を用い、順位・所属・タグは元データから補完する
+  const players = useMemo<PlayerDBProps[]>(() => {
+    if (!game || !playerList) return [];
+    return game.players.map((gamePlayer) => {
+      const master = playerList.find((player) => player.id === gamePlayer.id);
+      return {
+        id: gamePlayer.id,
+        name: gamePlayer.name,
+        text: master?.text ?? "",
+        belong: master?.belong ?? "",
+        tags: master?.tags ?? [],
+      };
+    });
+  }, [game, playerList]);
 
   const [showHeader] = useLocalStorage({
     key: "showBoardHeader",
@@ -67,20 +81,6 @@ const Board: React.FC<Props> = ({ game_id, current_profile }) => {
       document.title = `${game.name} | Score Watcher`;
     }
   }, [game]);
-
-  useEffect(() => {
-    if (playerList) {
-      const gamePlayers = (
-        game?.players.map((gamePlayer) =>
-          playerList.find((player) => player.id === gamePlayer.id)
-        ) || []
-      )
-        // undefined が消えてくれないのでタイプガードを使う
-        // https://qiita.com/suin/items/cda9af4f4f1c53c05c6f
-        .filter((v): v is PlayerDBProps => v !== undefined);
-      setPlayers(gamePlayers);
-    }
-  }, [playerList, game]);
 
   const [winThroughPlayer, setWinThroughPlayer] = useState<{
     name: string;

--- a/src/app/(board)/games/[game_id]/board/_components/Board/Board.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/Board/Board.tsx
@@ -53,8 +53,9 @@ const Board: React.FC<Props> = ({ game_id, current_profile }) => {
   // 表示名はゲーム独自名(game.players[].name)を用い、順位・所属・タグは元データから補完する
   const players = useMemo<PlayerDBProps[]>(() => {
     if (!game || !playerList) return [];
+    const masterById = new Map(playerList.map((player) => [player.id, player]));
     return game.players.map((gamePlayer) => {
-      const master = playerList.find((player) => player.id === gamePlayer.id);
+      const master = masterById.get(gamePlayer.id);
       return {
         id: gamePlayer.id,
         name: gamePlayer.name,

--- a/src/app/(default)/games/[game_id]/config/_components/EditPlayerModal/EditPlayerModal.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/EditPlayerModal/EditPlayerModal.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useTransition } from "react";
+
+import { Button, Group, Modal, TagsInput, TextInput } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { notifications } from "@mantine/notifications";
+
+import db from "@/utils/db";
+
+import type { PlayerDBProps } from "@/utils/types";
+
+type Props = {
+  opened: boolean;
+  onClose: () => void;
+  player: PlayerDBProps;
+  currentProfile: string;
+  onNameChange: (name: string) => void;
+};
+
+const EditPlayerModal: React.FC<Props> = ({
+  opened,
+  onClose,
+  player,
+  currentProfile,
+  onNameChange,
+}) => {
+  const [isPending, startTransition] = useTransition();
+  const form = useForm({
+    mode: "uncontrolled",
+    initialValues: {
+      name: player.name,
+      text: player.text,
+      belong: player.belong,
+      tags: player.tags,
+    },
+  });
+
+  /** 入力値を元データ(playersテーブル)へ保存し、このゲームの独自名にも反映する */
+  const handleSubmit = (values: typeof form.values) => {
+    startTransition(async () => {
+      await db(currentProfile).players.update(player.id, {
+        name: values.name,
+        text: values.text,
+        belong: values.belong,
+        tags: values.tags,
+      });
+      onNameChange(values.name);
+      notifications.show({
+        title: "プレイヤー情報を更新しました",
+        message: values.name,
+        autoClose: 5000,
+        withCloseButton: true,
+      });
+      onClose();
+    });
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="元データを編集" centered>
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <TextInput
+          label="氏名"
+          placeholder="越山識"
+          key={form.key("name")}
+          {...form.getInputProps("name")}
+        />
+        <TextInput
+          label="順位"
+          placeholder="24th"
+          mt="sm"
+          key={form.key("text")}
+          {...form.getInputProps("text")}
+        />
+        <TextInput
+          label="所属"
+          placeholder="文蔵高校"
+          mt="sm"
+          key={form.key("belong")}
+          {...form.getInputProps("belong")}
+        />
+        <TagsInput
+          label="タグ"
+          placeholder="Enterで追加"
+          mt="sm"
+          key={form.key("tags")}
+          {...form.getInputProps("tags")}
+        />
+        <Group justify="flex-end" mt="lg">
+          <Button variant="default" onClick={onClose} disabled={isPending}>
+            キャンセル
+          </Button>
+          <Button type="submit" loading={isPending}>
+            保存する
+          </Button>
+        </Group>
+      </form>
+    </Modal>
+  );
+};
+
+export default EditPlayerModal;

--- a/src/app/(default)/games/[game_id]/config/_components/EditPlayerModal/EditPlayerModal.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/EditPlayerModal/EditPlayerModal.tsx
@@ -39,20 +39,40 @@ const EditPlayerModal: React.FC<Props> = ({
   /** 入力値を元データ(playersテーブル)へ保存し、このゲームの独自名にも反映する */
   const handleSubmit = (values: typeof form.values) => {
     startTransition(async () => {
-      await db(currentProfile).players.update(player.id, {
-        name: values.name,
-        text: values.text,
-        belong: values.belong,
-        tags: values.tags,
-      });
-      onNameChange(values.name);
-      notifications.show({
-        title: "プレイヤー情報を更新しました",
-        message: values.name,
-        autoClose: 5000,
-        withCloseButton: true,
-      });
-      onClose();
+      try {
+        const updated = await db(currentProfile).players.update(player.id, {
+          name: values.name,
+          text: values.text,
+          belong: values.belong,
+          tags: values.tags,
+        });
+        if (updated === 0) {
+          notifications.show({
+            title: "プレイヤー情報を更新できませんでした",
+            message: "対象のプレイヤーが見つかりませんでした",
+            color: "red",
+            autoClose: 5000,
+            withCloseButton: true,
+          });
+          return;
+        }
+        onNameChange(values.name);
+        notifications.show({
+          title: "プレイヤー情報を更新しました",
+          message: values.name,
+          autoClose: 5000,
+          withCloseButton: true,
+        });
+        onClose();
+      } catch (error) {
+        notifications.show({
+          title: "プレイヤー情報の更新に失敗しました",
+          message: error instanceof Error ? error.message : "不明なエラーが発生しました",
+          color: "red",
+          autoClose: 5000,
+          withCloseButton: true,
+        });
+      }
     });
   };
 

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.module.css
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.module.css
@@ -1,0 +1,56 @@
+.card_wrapper {
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.card_header {
+  display: flex;
+  gap: var(--mantine-spacing-xs);
+  align-items: center;
+  margin-bottom: var(--mantine-spacing-sm);
+}
+
+.drag_handle {
+  display: flex;
+  align-items: center;
+  color: var(--mantine-color-gray-5);
+  cursor: grab;
+}
+
+.index {
+  font-size: var(--mantine-font-size-sm);
+  font-weight: 700;
+  color: var(--mantine-color-dimmed);
+}
+
+.spacer {
+  flex: 1;
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-sm);
+
+  @media (width >= 48em) {
+    flex-flow: row wrap;
+    align-items: flex-end;
+  }
+}
+
+.name_field {
+  width: 100%;
+
+  @media (width >= 48em) {
+    flex: 1 1 12rem;
+    width: auto;
+  }
+}
+
+.number_field {
+  width: 100%;
+
+  @media (width >= 48em) {
+    flex: 0 0 7rem;
+    width: auto;
+  }
+}

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.module.css
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.module.css
@@ -2,6 +2,10 @@
   margin-bottom: var(--mantine-spacing-md);
 }
 
+.card_dragging {
+  border-color: var(--mantine-primary-color-filled);
+}
+
 .card_header {
   display: flex;
   gap: var(--mantine-spacing-xs);
@@ -26,6 +30,22 @@
   flex: 1;
 }
 
+.detail_toggle {
+  display: inline-flex;
+
+  @media (width >= 48em) {
+    display: none;
+  }
+}
+
+.chevron {
+  transition: transform 150ms ease;
+}
+
+.chevron_open {
+  transform: rotate(180deg);
+}
+
 .fields {
   display: flex;
   flex-direction: column;
@@ -37,13 +57,34 @@
   }
 }
 
-.name_field {
-  width: 100%;
+.name_row {
+  display: flex;
+  gap: var(--mantine-spacing-xs);
+  align-items: flex-end;
 
   @media (width >= 48em) {
     flex: 1 1 12rem;
-    width: auto;
   }
+}
+
+.name_field {
+  flex: 1;
+}
+
+.detail_fields {
+  display: none;
+  flex-direction: column;
+  gap: var(--mantine-spacing-sm);
+
+  @media (width >= 48em) {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-end;
+  }
+}
+
+.detail_fields_expanded {
+  display: flex;
 }
 
 .number_field {

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
@@ -29,7 +29,7 @@ type Props = {
 };
 
 const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, currentProfile }) => {
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
   // SPでは名前以外のフィールドを折り畳む。開いているプレイヤーをidで保持する
   const [openDetailIds, setOpenDetailIds] = useState<string[]>([]);
   const form = useForm({
@@ -79,7 +79,7 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
                   <Menu.Dropdown>
                     <Menu.Item
                       leftSection={<IconPencil size="1rem" />}
-                      onClick={() => setEditingIndex(index)}
+                      onClick={() => setEditingId(item.id)}
                     >
                       元データを編集
                     </Menu.Item>
@@ -176,9 +176,7 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
     );
   });
 
-  const editingGamePlayerId =
-    editingIndex !== null ? form.getValues().players[editingIndex]?.id : undefined;
-  const editingPlayer = playerList.find((player) => player.id === editingGamePlayerId);
+  const editingPlayer = playerList.find((player) => player.id === editingId);
 
   return (
     <>
@@ -211,14 +209,20 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
         players={players}
         form={form}
       />
-      {editingIndex !== null && editingPlayer && (
+      {editingPlayer && (
         <EditPlayerModal
           key={editingPlayer.id}
           opened
-          onClose={() => setEditingIndex(null)}
+          onClose={() => setEditingId(null)}
           player={editingPlayer}
           currentProfile={currentProfile}
-          onNameChange={(name) => form.setFieldValue(`players.${editingIndex}.name`, name)}
+          onNameChange={(name) => {
+            // 保存時点の最新の並びからindexを引き直し、別プレイヤーへの誤適用を防ぐ
+            const index = form.getValues().players.findIndex((player) => player.id === editingId);
+            if (index !== -1) {
+              form.setFieldValue(`players.${index}.name`, name);
+            }
+          }}
         />
       )}
     </>

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import { useState } from "react";
+
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
-import { Center, Group, NumberInput, ScrollArea, TextInput } from "@mantine/core";
+import { ActionIcon, Center, Group, Menu, NumberInput, ScrollArea, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { IconGripVertical } from "@tabler/icons-react";
+import { IconDotsVertical, IconGripVertical, IconPencil } from "@tabler/icons-react";
 
 import db from "@/utils/db";
 
+import EditPlayerModal from "./EditPlayerModal/EditPlayerModal";
 import SelectPlayer from "./SelectPlayer/SelectPlayer";
 
 import type { GameDBPlayerProps, PlayerDBProps, RuleNames } from "@/utils/types";
@@ -20,6 +23,7 @@ type Props = {
 };
 
 const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, currentProfile }) => {
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const form = useForm({
     mode: "uncontrolled",
     initialValues: {
@@ -92,11 +96,30 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
                 />
               </>
             )}
+            <Menu position="bottom-end" withinPortal>
+              <Menu.Target>
+                <ActionIcon variant="subtle" color="gray" mt="xl" aria-label="プレイヤー操作">
+                  <IconDotsVertical size="1.2rem" />
+                </ActionIcon>
+              </Menu.Target>
+              <Menu.Dropdown>
+                <Menu.Item
+                  leftSection={<IconPencil size="1rem" />}
+                  onClick={() => setEditingIndex(index)}
+                >
+                  元データを編集
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
           </Group>
         </ScrollArea>
       )}
     </Draggable>
   ));
+
+  const editingGamePlayerId =
+    editingIndex !== null ? form.getValues().players[editingIndex]?.id : undefined;
+  const editingPlayer = playerList.find((player) => player.id === editingGamePlayerId);
 
   return (
     <>
@@ -129,6 +152,16 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
         players={players}
         form={form}
       />
+      {editingIndex !== null && editingPlayer && (
+        <EditPlayerModal
+          key={editingPlayer.id}
+          opened
+          onClose={() => setEditingIndex(null)}
+          player={editingPlayer}
+          currentProfile={currentProfile}
+          onNameChange={(name) => form.setFieldValue(`players.${editingIndex}.name`, name)}
+        />
+      )}
     </>
   );
 };

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
@@ -3,13 +3,14 @@
 import { useState } from "react";
 
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
-import { ActionIcon, Center, Group, Menu, NumberInput, ScrollArea, TextInput } from "@mantine/core";
+import { ActionIcon, Card, Center, Menu, NumberInput, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { IconDotsVertical, IconGripVertical, IconPencil } from "@tabler/icons-react";
 
 import db from "@/utils/db";
 
 import EditPlayerModal from "./EditPlayerModal/EditPlayerModal";
+import classes from "./PlayersConfig.module.css";
 import SelectPlayer from "./SelectPlayer/SelectPlayer";
 
 import type { GameDBPlayerProps, PlayerDBProps, RuleNames } from "@/utils/types";
@@ -42,77 +43,87 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
   const fields = form.getValues().players.map((item, index) => (
     <Draggable key={item.id} index={index} draggableId={item.id}>
       {(provided) => (
-        <ScrollArea offsetScrollbars ref={provided.innerRef} {...provided.draggableProps}>
-          <Group w={500} wrap="nowrap">
-            <Center {...provided.dragHandleProps}>
-              <IconGripVertical size="1.2rem" />
-            </Center>
-            <TextInput
-              label="プレイヤー名"
-              placeholder="John Doe"
-              size="md"
-              key={form.key(`players.${index}.name`)}
-              {...form.getInputProps(`players.${index}.name`)}
-            />
-            {rule !== "squarex" && (
-              <>
+        <div ref={provided.innerRef} className={classes.card_wrapper} {...provided.draggableProps}>
+          <Card withBorder radius="md" shadow="sm" p="md">
+            <div className={classes.card_header}>
+              <Center {...provided.dragHandleProps} className={classes.drag_handle}>
+                <IconGripVertical size="1.2rem" />
+              </Center>
+              <span className={classes.index}>プレイヤー {index + 1}</span>
+              <div className={classes.spacer} />
+              <Menu position="bottom-end" withinPortal>
+                <Menu.Target>
+                  <ActionIcon variant="subtle" color="gray" aria-label="プレイヤー操作">
+                    <IconDotsVertical size="1.2rem" />
+                  </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                  <Menu.Item
+                    leftSection={<IconPencil size="1rem" />}
+                    onClick={() => setEditingIndex(index)}
+                  >
+                    元データを編集
+                  </Menu.Item>
+                </Menu.Dropdown>
+              </Menu>
+            </div>
+            <div className={classes.fields}>
+              <TextInput
+                className={classes.name_field}
+                label="プレイヤー名"
+                placeholder="John Doe"
+                size="md"
+                key={form.key(`players.${index}.name`)}
+                {...form.getInputProps(`players.${index}.name`)}
+              />
+              {rule !== "squarex" && (
+                <>
+                  <NumberInput
+                    className={classes.number_field}
+                    label="初期正答数"
+                    size="md"
+                    key={form.key(`players.${index}.initial_correct`)}
+                    {...form.getInputProps(`players.${index}.initial_correct`)}
+                  />
+                  <NumberInput
+                    className={classes.number_field}
+                    label="初期誤答数"
+                    size="md"
+                    key={form.key(`players.${index}.initial_wrong`)}
+                    {...form.getInputProps(`players.${index}.initial_wrong`)}
+                  />
+                </>
+              )}
+              {rule === "squarex" && (
+                <>
+                  <NumberInput
+                    className={classes.number_field}
+                    label="奇数問目の正解数"
+                    size="md"
+                    key={form.key(`players.${index}.initial_correct`)}
+                    {...form.getInputProps(`players.${index}.initial_correct`)}
+                  />
+                  <NumberInput
+                    className={classes.number_field}
+                    label="偶数問目の正解数"
+                    size="md"
+                    key={form.key(`players.${index}.initial_wrong`)}
+                    {...form.getInputProps(`players.${index}.initial_wrong`)}
+                  />
+                </>
+              )}
+              {rule === "variables" && (
                 <NumberInput
-                  label="初期正答数"
-                  size="md"
-                  key={form.key(`players.${index}.initial_correct`)}
-                  {...form.getInputProps(`players.${index}.initial_correct`)}
-                />
-                <NumberInput
-                  label="初期誤答数"
-                  size="md"
-                  key={form.key(`players.${index}.initial_wrong`)}
-                  {...form.getInputProps(`players.${index}.initial_wrong`)}
-                />
-              </>
-            )}
-            {rule === "squarex" && (
-              <>
-                <NumberInput
-                  label="奇数問目の正解数"
-                  size="md"
-                  key={form.key(`players.${index}.initial_correct`)}
-                  {...form.getInputProps(`players.${index}.initial_correct`)}
-                />
-                <NumberInput
-                  label="偶数問目の正解数"
-                  size="md"
-                  key={form.key(`players.${index}.initial_wrong`)}
-                  {...form.getInputProps(`players.${index}.initial_wrong`)}
-                />
-              </>
-            )}
-            {rule === "variables" && (
-              <>
-                <NumberInput
+                  className={classes.number_field}
                   label="N"
                   size="md"
                   key={form.key(`players.${index}.base_correct_point`)}
                   {...form.getInputProps(`players.${index}.base_correct_point`)}
                 />
-              </>
-            )}
-            <Menu position="bottom-end" withinPortal>
-              <Menu.Target>
-                <ActionIcon variant="subtle" color="gray" mt="xl" aria-label="プレイヤー操作">
-                  <IconDotsVertical size="1.2rem" />
-                </ActionIcon>
-              </Menu.Target>
-              <Menu.Dropdown>
-                <Menu.Item
-                  leftSection={<IconPencil size="1rem" />}
-                  onClick={() => setEditingIndex(index)}
-                >
-                  元データを編集
-                </Menu.Item>
-              </Menu.Dropdown>
-            </Menu>
-          </Group>
-        </ScrollArea>
+              )}
+            </div>
+          </Card>
+        </div>
       )}
     </Draggable>
   ));

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
@@ -5,7 +5,12 @@ import { useState } from "react";
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
 import { ActionIcon, Card, Center, Menu, NumberInput, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
-import { IconDotsVertical, IconGripVertical, IconPencil } from "@tabler/icons-react";
+import {
+  IconChevronDown,
+  IconDotsVertical,
+  IconGripVertical,
+  IconPencil,
+} from "@tabler/icons-react";
 
 import db from "@/utils/db";
 
@@ -25,6 +30,8 @@ type Props = {
 
 const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, currentProfile }) => {
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  // SPでは名前以外のフィールドを折り畳む。開いているプレイヤーをidで保持する
+  const [openDetailIds, setOpenDetailIds] = useState<string[]>([]);
   const form = useForm({
     mode: "uncontrolled",
     initialValues: {
@@ -40,93 +47,134 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
     },
   });
 
-  const fields = form.getValues().players.map((item, index) => (
-    <Draggable key={item.id} index={index} draggableId={item.id}>
-      {(provided) => (
-        <div ref={provided.innerRef} className={classes.card_wrapper} {...provided.draggableProps}>
-          <Card withBorder radius="md" shadow="sm" p="md">
-            <div className={classes.card_header}>
-              <Center {...provided.dragHandleProps} className={classes.drag_handle}>
-                <IconGripVertical size="1.2rem" />
-              </Center>
-              <span className={classes.index}>プレイヤー {index + 1}</span>
-              <div className={classes.spacer} />
-              <Menu position="bottom-end" withinPortal>
-                <Menu.Target>
-                  <ActionIcon variant="subtle" color="gray" aria-label="プレイヤー操作">
-                    <IconDotsVertical size="1.2rem" />
-                  </ActionIcon>
-                </Menu.Target>
-                <Menu.Dropdown>
-                  <Menu.Item
-                    leftSection={<IconPencil size="1rem" />}
-                    onClick={() => setEditingIndex(index)}
+  const fields = form.getValues().players.map((item, index) => {
+    const detailOpen = openDetailIds.includes(item.id);
+    return (
+      <Draggable key={item.id} index={index} draggableId={item.id}>
+        {(provided, snapshot) => (
+          <div
+            ref={provided.innerRef}
+            className={classes.card_wrapper}
+            {...provided.draggableProps}
+          >
+            <Card
+              withBorder
+              radius="md"
+              shadow={snapshot.isDragging ? "xl" : "sm"}
+              p="md"
+              className={snapshot.isDragging ? classes.card_dragging : undefined}
+            >
+              <div className={classes.card_header}>
+                <Center {...provided.dragHandleProps} className={classes.drag_handle}>
+                  <IconGripVertical size="1.2rem" />
+                </Center>
+                <span className={classes.index}>プレイヤー {index + 1}</span>
+                <div className={classes.spacer} />
+                <Menu position="bottom-end" withinPortal>
+                  <Menu.Target>
+                    <ActionIcon variant="subtle" color="gray" aria-label="プレイヤー操作">
+                      <IconDotsVertical size="1.2rem" />
+                    </ActionIcon>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    <Menu.Item
+                      leftSection={<IconPencil size="1rem" />}
+                      onClick={() => setEditingIndex(index)}
+                    >
+                      元データを編集
+                    </Menu.Item>
+                  </Menu.Dropdown>
+                </Menu>
+              </div>
+              <div className={classes.fields}>
+                <div className={classes.name_row}>
+                  <TextInput
+                    className={classes.name_field}
+                    label="プレイヤー名"
+                    placeholder="John Doe"
+                    size="md"
+                    key={form.key(`players.${index}.name`)}
+                    {...form.getInputProps(`players.${index}.name`)}
+                  />
+                  <ActionIcon
+                    variant="subtle"
+                    color="gray"
+                    size="lg"
+                    className={classes.detail_toggle}
+                    aria-label="詳細設定の開閉"
+                    aria-expanded={detailOpen}
+                    onClick={() =>
+                      setOpenDetailIds((prev) =>
+                        prev.includes(item.id)
+                          ? prev.filter((id) => id !== item.id)
+                          : [...prev, item.id]
+                      )
+                    }
                   >
-                    元データを編集
-                  </Menu.Item>
-                </Menu.Dropdown>
-              </Menu>
-            </div>
-            <div className={classes.fields}>
-              <TextInput
-                className={classes.name_field}
-                label="プレイヤー名"
-                placeholder="John Doe"
-                size="md"
-                key={form.key(`players.${index}.name`)}
-                {...form.getInputProps(`players.${index}.name`)}
-              />
-              {rule !== "squarex" && (
-                <>
-                  <NumberInput
-                    className={classes.number_field}
-                    label="初期正答数"
-                    size="md"
-                    key={form.key(`players.${index}.initial_correct`)}
-                    {...form.getInputProps(`players.${index}.initial_correct`)}
-                  />
-                  <NumberInput
-                    className={classes.number_field}
-                    label="初期誤答数"
-                    size="md"
-                    key={form.key(`players.${index}.initial_wrong`)}
-                    {...form.getInputProps(`players.${index}.initial_wrong`)}
-                  />
-                </>
-              )}
-              {rule === "squarex" && (
-                <>
-                  <NumberInput
-                    className={classes.number_field}
-                    label="奇数問目の正解数"
-                    size="md"
-                    key={form.key(`players.${index}.initial_correct`)}
-                    {...form.getInputProps(`players.${index}.initial_correct`)}
-                  />
-                  <NumberInput
-                    className={classes.number_field}
-                    label="偶数問目の正解数"
-                    size="md"
-                    key={form.key(`players.${index}.initial_wrong`)}
-                    {...form.getInputProps(`players.${index}.initial_wrong`)}
-                  />
-                </>
-              )}
-              {rule === "variables" && (
-                <NumberInput
-                  className={classes.number_field}
-                  label="N"
-                  size="md"
-                  key={form.key(`players.${index}.base_correct_point`)}
-                  {...form.getInputProps(`players.${index}.base_correct_point`)}
-                />
-              )}
-            </div>
-          </Card>
-        </div>
-      )}
-    </Draggable>
-  ));
+                    <IconChevronDown
+                      size="1.2rem"
+                      className={detailOpen ? classes.chevron_open : classes.chevron}
+                    />
+                  </ActionIcon>
+                </div>
+                <div
+                  className={`${classes.detail_fields} ${
+                    detailOpen ? classes.detail_fields_expanded : ""
+                  }`}
+                >
+                  {rule !== "squarex" && (
+                    <>
+                      <NumberInput
+                        className={classes.number_field}
+                        label="初期正答数"
+                        size="md"
+                        key={form.key(`players.${index}.initial_correct`)}
+                        {...form.getInputProps(`players.${index}.initial_correct`)}
+                      />
+                      <NumberInput
+                        className={classes.number_field}
+                        label="初期誤答数"
+                        size="md"
+                        key={form.key(`players.${index}.initial_wrong`)}
+                        {...form.getInputProps(`players.${index}.initial_wrong`)}
+                      />
+                    </>
+                  )}
+                  {rule === "squarex" && (
+                    <>
+                      <NumberInput
+                        className={classes.number_field}
+                        label="奇数問目の正解数"
+                        size="md"
+                        key={form.key(`players.${index}.initial_correct`)}
+                        {...form.getInputProps(`players.${index}.initial_correct`)}
+                      />
+                      <NumberInput
+                        className={classes.number_field}
+                        label="偶数問目の正解数"
+                        size="md"
+                        key={form.key(`players.${index}.initial_wrong`)}
+                        {...form.getInputProps(`players.${index}.initial_wrong`)}
+                      />
+                    </>
+                  )}
+                  {rule === "variables" && (
+                    <NumberInput
+                      className={classes.number_field}
+                      label="N"
+                      size="md"
+                      key={form.key(`players.${index}.base_correct_point`)}
+                      {...form.getInputProps(`players.${index}.base_correct_point`)}
+                    />
+                  )}
+                </div>
+              </div>
+            </Card>
+          </div>
+        )}
+      </Draggable>
+    );
+  });
 
   const editingGamePlayerId =
     editingIndex !== null ? form.getValues().players[editingIndex]?.id : undefined;


### PR DESCRIPTION
## 概要

issue #143「プレイヤー設定タブで名前を変えても反映されない」の修正と、関連する機能追加を行いました。

## 背景・原因

設定画面のプレイヤー名編集は `games` テーブルの `game.players[].name` に保存されますが、スコアボード(`Board.tsx`)は表示時に `players`テーブル(マスタ)から名前を引き直していたため、変更が反映されませんでした。

## 変更内容

### 1. スコアボードの表示名をゲーム独自名に切替（#143 本体）
- `Board.tsx` の表示用 `players` を `useState`+`useEffect` での導出から `useMemo` に変更（AGENTS.md のデータ導出に useEffect を使わない方針に準拠）。
- 表示名を `game.players[].name`（ゲーム独自名）から取得。順位・所属・タグは引き続きマスタ(`players`)からマージ。
- `computeScore` / `win_players.name` は元から `game.players` 基準のため整合します。

### 2. 元データ編集ダイアログを追加
- 新規 `EditPlayerModal` を実装し、**氏名・順位・所属・タグ** を編集可能に（タグは `TagsInput`）。
- 保存時に `db().players.update` で元データを更新。`useTransition` でローディング表示。
- 氏名変更時は、このゲームの独自名(`game.players[].name`)も連動して更新。

### 3. プレイヤー設定タブに `⋮` メニュー
- 各プレイヤー行に `Menu` + `ActionIcon`(⋮) を追加し、「元データを編集」からダイアログを起動。

## 動作確認

- `npx tsc --noEmit` ✅
- `pnpm run lint:fix` ✅
- `pnpm run vitest` ✅ 81 件すべて pass

手動確認の観点:
- 設定タブで「プレイヤー名」を変更 → ボードに反映されること
- ⋮ →「元データを編集」で順位・所属・タグを変更 → ボードのヘッダーに反映されること
- ダイアログで氏名を変更 → ボードの表示名と設定タブの名前が連動更新されること

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)