### PR TITLE
style: タブメニューを横並び・着色・文字拡大に統一 (#148)

### DIFF
--- a/src/app/(default)/games/[game_id]/config/_components/Config/Config.module.css
+++ b/src/app/(default)/games/[game_id]/config/_components/Config/Config.module.css
@@ -3,10 +3,16 @@
 }
 
 .tab_list {
+  & button {
+    padding-block: 1rem;
+    font-size: 1.125rem;
+    font-weight: 700;
+  }
+
   & button[data-active="true"] {
     color: var(--mantine-color-gray-9);
     background-color: var(--mantine-color-gray-1);
-    border-right: 1px solid transparent;
+    border-bottom-color: transparent;
 
     @mixin dark {
       color: var(--mantine-color-gray-1);
@@ -15,18 +21,16 @@
   }
 }
 
-.tab_panel_area {
-  flex-grow: 1;
-  min-height: 80vh;
+.tab_panel {
+  min-height: 60vh;
   padding: 1rem;
-  overflow: scroll;
   background-color: var(--mantine-color-gray-1);
   border: 1px solid var(--mantine-color-gray-3);
-  border-left: 1px solid transparent;
+  border-top: none;
+  border-radius: 0 0 0.5rem 0.5rem;
 
   @mixin dark {
     background-color: var(--mantine-color-gray-8);
-    border: 1px solid var(--mantine-color-gray-7);
-    border-left: 1px solid transparent;
+    border-color: var(--mantine-color-gray-7);
   }
 }

--- a/src/app/(default)/games/[game_id]/config/_components/Config/Config.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/Config/Config.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Accordion, Box, Tabs } from "@mantine/core";
+import { Accordion, Tabs } from "@mantine/core";
 import { useLocalStorage } from "@mantine/hooks";
 import { useLiveQuery } from "dexie-react-hooks";
 
@@ -63,35 +63,27 @@ const Config: React.FC<Props> = ({ game_id, currentProfile }) => {
         </Accordion.Item>
       </Accordion>
       <GameStartButton game={game} logs={logs} disabled={disabled} />
-      <Tabs
-        pt="lg"
-        variant="outline"
-        orientation="vertical"
-        defaultValue="rule"
-        className={classes.tabs_area}
-      >
-        <Tabs.List className={classes.tab_list}>
+      <Tabs pt="lg" variant="outline" defaultValue="player" className={classes.tabs_area}>
+        <Tabs.List mt="lg" grow className={classes.tab_list}>
           <Tabs.Tab value="rule">形式設定</Tabs.Tab>
           <Tabs.Tab value="player">プレイヤー設定</Tabs.Tab>
           <Tabs.Tab value="other">その他の設定</Tabs.Tab>
         </Tabs.List>
-        <Box className={classes.tab_panel_area}>
-          <Tabs.Panel value="rule">
-            <RuleSettings game={game} currentProfile={storedCurrentProfile} />
-          </Tabs.Panel>
-          <Tabs.Panel value="player">
-            <PlayersConfig
-              game_id={game.id}
-              rule={game.rule}
-              playerList={players}
-              players={game.players}
-              currentProfile={storedCurrentProfile}
-            />
-          </Tabs.Panel>
-          <Tabs.Panel value="other">
-            <OtherConfig game={game} currentProfile={storedCurrentProfile} />
-          </Tabs.Panel>
-        </Box>
+        <Tabs.Panel value="rule" className={classes.tab_panel}>
+          <RuleSettings game={game} currentProfile={storedCurrentProfile} />
+        </Tabs.Panel>
+        <Tabs.Panel value="player" className={classes.tab_panel}>
+          <PlayersConfig
+            game_id={game.id}
+            rule={game.rule}
+            playerList={players}
+            players={game.players}
+            currentProfile={storedCurrentProfile}
+          />
+        </Tabs.Panel>
+        <Tabs.Panel value="other" className={classes.tab_panel}>
+          <OtherConfig game={game} currentProfile={storedCurrentProfile} />
+        </Tabs.Panel>
       </Tabs>
     </>
   );

--- a/src/app/(default)/players/_components/ManagePlayer/ManagePlayer.module.css
+++ b/src/app/(default)/players/_components/ManagePlayer/ManagePlayer.module.css
@@ -1,6 +1,31 @@
+.tab_list {
+  & button {
+    padding-block: 1rem;
+    font-size: 1.125rem;
+    font-weight: 700;
+  }
+
+  & button[data-active="true"] {
+    color: var(--mantine-color-gray-9);
+    background-color: var(--mantine-color-gray-1);
+    border-bottom-color: transparent;
+
+    @mixin dark {
+      color: var(--mantine-color-gray-1);
+      background-color: var(--mantine-color-gray-8);
+    }
+  }
+}
+
 .tab_panel {
   padding: 1rem;
-  border: 1px solid var(--tab-border-color);
+  background-color: var(--mantine-color-gray-1);
+  border: 1px solid var(--mantine-color-gray-3);
   border-top: none;
   border-radius: 0 0 0.5rem 0.5rem;
+
+  @mixin dark {
+    background-color: var(--mantine-color-gray-8);
+    border-color: var(--mantine-color-gray-7);
+  }
 }

--- a/src/app/(default)/players/_components/ManagePlayer/ManagePlayer.tsx
+++ b/src/app/(default)/players/_components/ManagePlayer/ManagePlayer.tsx
@@ -29,7 +29,7 @@ const ManagePlayer: React.FC<Props> = ({ currentProfile, from }) => {
       <Title order={2}>プレイヤー管理</Title>
       <h3>プレイヤーの読み込み</h3>
       <Tabs pt="lg" variant="outline" defaultValue="add">
-        <Tabs.List mt="lg" grow>
+        <Tabs.List mt="lg" grow className={classes.tab_list}>
           <Tabs.Tab value="add">個別に追加</Tabs.Tab>
           <Tabs.Tab value="paste">貼り付け</Tabs.Tab>
           <Tabs.Tab value="import">インポート</Tabs.Tab>

--- a/src/app/(default)/quizes/_components/ManageQuiz/ManageQuiz.module.css
+++ b/src/app/(default)/quizes/_components/ManageQuiz/ManageQuiz.module.css
@@ -1,6 +1,31 @@
+.tab_list {
+  & button {
+    padding-block: 1rem;
+    font-size: 1.125rem;
+    font-weight: 700;
+  }
+
+  & button[data-active="true"] {
+    color: var(--mantine-color-gray-9);
+    background-color: var(--mantine-color-gray-1);
+    border-bottom-color: transparent;
+
+    @mixin dark {
+      color: var(--mantine-color-gray-1);
+      background-color: var(--mantine-color-gray-8);
+    }
+  }
+}
+
 .tab_panel {
   padding: 1rem;
-  border: 1px solid var(--tab-border-color);
+  background-color: var(--mantine-color-gray-1);
+  border: 1px solid var(--mantine-color-gray-3);
   border-top: none;
   border-radius: 0 0 0.5rem 0.5rem;
+
+  @mixin dark {
+    background-color: var(--mantine-color-gray-8);
+    border-color: var(--mantine-color-gray-7);
+  }
 }

--- a/src/app/(default)/quizes/_components/ManageQuiz/ManageQuiz.tsx
+++ b/src/app/(default)/quizes/_components/ManageQuiz/ManageQuiz.tsx
@@ -29,7 +29,7 @@ const ManageQuiz: React.FC<Props> = ({ currentProfile }) => {
       <h3>問題の読み込み</h3>
       <TextInput label="セット名" onChange={(e) => setSetName(e.target.value)} value={setName} />
       <Tabs pt="lg" variant="outline" defaultValue="paste">
-        <Tabs.List mt="lg" grow>
+        <Tabs.List mt="lg" grow className={classes.tab_list}>
           <Tabs.Tab value="paste">貼り付け</Tabs.Tab>
           <Tabs.Tab value="import">インポート</Tabs.Tab>
         </Tabs.List>

--- a/tests/game.spec.ts
+++ b/tests/game.spec.ts
@@ -165,6 +165,8 @@ test.describe("誤答数の記号表示", () => {
   });
 
   test("失格誤答数を増やして敗退を防ぐ", async () => {
+    // 初期表示は「プレイヤー設定」タブのため、形式設定タブを開く
+    await page.getByRole("tab", { name: "形式設定" }).click();
     // 既定では誤答3回で失格になるため、表示検証のため失格誤答数を増やす
     const losePointInput = page.getByLabel("失格誤答数");
     await losePointInput.fill("10");


### PR DESCRIPTION
## 概要

Issue #148 対応。Mantine の `Tabs` は特に horizontal 表示で色が薄く存在に気づきにくかったため、視認性と一貫性を改善した。

## 変更内容

- **横並びに統一**: ゲーム設定ページ（Config）を vertical → horizontal に変更し、プレイヤー管理・問題管理ページと向きを揃えた
- **着色**: アクティブタブとパネル背景をグレー（`gray-1`/`gray-8`、ダーク対応）で着色。Config の従来スタイルを全ページへ展開
- **文字拡大・高さ拡大**: タブ文字を `1.125rem`・太字にし、`padding-block: 1rem` でタブ自体を押しやすく
- **初期タブ変更**: ゲーム設定画面の初期表示タブを「形式設定」→「プレイヤー設定」に変更
- 未定義だった `--tab-border-color` 参照を `gray-3`/`gray-7` に置換して解消

対象は管理ページ系3箇所。`PreferenceDrawer`（表示設定Drawer）は対象外。

## 確認

- `npx tsc --noEmit` / lint / stylelint 通過
- Playwright で3ページの横並び・着色・文字拡大、Config のタブ切替動作を目視確認

close #148 

🤖 Generated with [Claude Code](https://claude.com/claude-code)