### PR TITLE
feat: ゲーム設定のプレイヤータブでプレイヤーを削除できるようにする (#158)

### DIFF
--- a/src/app/(default)/games/[game_id]/config/_components/CompactPlayerTable.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/CompactPlayerTable.tsx
@@ -123,17 +123,19 @@ const CompactPlayerTable: React.FC<Props> = ({
     })();
   }, []);
 
-  // カードからの削除などで外部からgamePlayersが変化した際に選択状態を同期する
+  // カードからの削除などで外部からgamePlayersやplayerListが変化した際に選択状態を同期する
   const gamePlayerIdsKey = gamePlayerIds.join(",");
+  const playerListKey = playerList.map((player) => player.id).join(",");
   useDidUpdate(() => {
+    const gamePlayerIdSet = new Set(gamePlayerIds);
     const newRowSelection: { [key: number]: boolean } = {};
     playerList.forEach((player, i) => {
-      if (gamePlayerIds.includes(player.id)) {
+      if (gamePlayerIdSet.has(player.id)) {
         newRowSelection[i] = true;
       }
     });
     setRowSelection(newRowSelection);
-  }, [gamePlayerIdsKey]);
+  }, [gamePlayerIdsKey, playerListKey]);
 
   // didにしておかないと選択状態がリセットされる
   useDidUpdate(() => {

--- a/src/app/(default)/games/[game_id]/config/_components/CompactPlayerTable.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/CompactPlayerTable.tsx
@@ -123,6 +123,18 @@ const CompactPlayerTable: React.FC<Props> = ({
     })();
   }, []);
 
+  // カードからの削除などで外部からgamePlayersが変化した際に選択状態を同期する
+  const gamePlayerIdsKey = gamePlayerIds.join(",");
+  useDidUpdate(() => {
+    const newRowSelection: { [key: number]: boolean } = {};
+    playerList.forEach((player, i) => {
+      if (gamePlayerIds.includes(player.id)) {
+        newRowSelection[i] = true;
+      }
+    });
+    setRowSelection(newRowSelection);
+  }, [gamePlayerIdsKey]);
+
   // didにしておかないと選択状態がリセットされる
   useDidUpdate(() => {
     (async () => {

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.module.css
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.module.css
@@ -2,6 +2,11 @@
   margin-bottom: var(--mantine-spacing-md);
 }
 
+.inline_icon {
+  margin: 0 0.1rem;
+  vertical-align: middle;
+}
+
 .card_dragging {
   border-color: var(--mantine-primary-color-filled);
 }

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
@@ -3,14 +3,16 @@
 import { useState } from "react";
 
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
-import { ActionIcon, Card, Center, Menu, NumberInput, TextInput } from "@mantine/core";
+import { ActionIcon, Card, Center, Menu, NumberInput, Text, TextInput } from "@mantine/core";
 import { useForm } from "@mantine/form";
 import {
   IconChevronDown,
   IconDotsVertical,
   IconGripVertical,
   IconPencil,
+  IconTrash,
 } from "@tabler/icons-react";
+import { useLiveQuery } from "dexie-react-hooks";
 
 import db from "@/utils/db";
 
@@ -32,6 +34,7 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
   const [editingId, setEditingId] = useState<string | null>(null);
   // SPでは名前以外のフィールドを折り畳む。開いているプレイヤーをidで保持する
   const [openDetailIds, setOpenDetailIds] = useState<string[]>([]);
+  const logs = useLiveQuery(() => db(currentProfile).logs.toArray(), []);
   const form = useForm({
     mode: "uncontrolled",
     initialValues: {
@@ -46,6 +49,22 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
       }
     },
   });
+
+  /**
+   * このゲームからプレイヤーを削除する。プレイヤーの元データは削除せず、ゲームの参加者から外す。
+   * @param playerId 削除するプレイヤーのid
+   */
+  const deleteGamePlayer = async (playerId: string) => {
+    const newPlayers = form.getValues().players.filter((player) => player.id !== playerId);
+    const deleteLogIdList = logs
+      ?.filter((log) => log.game_id === game_id && log.player_id === playerId)
+      .map((log) => log.id);
+    if (deleteLogIdList && deleteLogIdList.length > 0) {
+      await db(currentProfile).logs.bulkDelete(deleteLogIdList);
+    }
+    await db(currentProfile).games.update(game_id, { players: newPlayers });
+    form.setFieldValue("players", newPlayers);
+  };
 
   const fields = form.getValues().players.map((item, index) => {
     const detailOpen = openDetailIds.includes(item.id);
@@ -82,6 +101,13 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
                       onClick={() => setEditingId(item.id)}
                     >
                       元データを編集
+                    </Menu.Item>
+                    <Menu.Item
+                      color="red"
+                      leftSection={<IconTrash size="1rem" />}
+                      onClick={() => deleteGamePlayer(item.id)}
+                    >
+                      プレイヤーを削除
                     </Menu.Item>
                   </Menu.Dropdown>
                 </Menu>
@@ -182,6 +208,11 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
     <>
       {players.length !== 0 && (
         <>
+          <Text size="sm" c="dimmed" mb="md">
+            プレイヤー左上の
+            <IconGripVertical size="1rem" className={classes.inline_icon} />
+            アイコンを持ってドラッグすると順番を変えられます。
+          </Text>
           <DragDropContext
             onDragEnd={({ destination, source }) =>
               destination?.index !== undefined &&

--- a/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/PlayersConfig.tsx
@@ -12,7 +12,6 @@ import {
   IconPencil,
   IconTrash,
 } from "@tabler/icons-react";
-import { useLiveQuery } from "dexie-react-hooks";
 
 import db from "@/utils/db";
 
@@ -34,7 +33,6 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
   const [editingId, setEditingId] = useState<string | null>(null);
   // SPでは名前以外のフィールドを折り畳む。開いているプレイヤーをidで保持する
   const [openDetailIds, setOpenDetailIds] = useState<string[]>([]);
-  const logs = useLiveQuery(() => db(currentProfile).logs.toArray(), []);
   const form = useForm({
     mode: "uncontrolled",
     initialValues: {
@@ -56,13 +54,16 @@ const PlayersConfig: React.FC<Props> = ({ game_id, rule, playerList, players, cu
    */
   const deleteGamePlayer = async (playerId: string) => {
     const newPlayers = form.getValues().players.filter((player) => player.id !== playerId);
-    const deleteLogIdList = logs
-      ?.filter((log) => log.game_id === game_id && log.player_id === playerId)
-      .map((log) => log.id);
-    if (deleteLogIdList && deleteLogIdList.length > 0) {
-      await db(currentProfile).logs.bulkDelete(deleteLogIdList);
-    }
-    await db(currentProfile).games.update(game_id, { players: newPlayers });
+    const client = db(currentProfile);
+    await client.transaction("rw", client.logs, client.games, async () => {
+      // 該当ゲーム・該当プレイヤーの操作ログを削除する
+      await client.logs
+        .where("game_id")
+        .equals(game_id)
+        .and((log) => log.player_id === playerId)
+        .delete();
+      await client.games.update(game_id, { players: newPlayers });
+    });
     form.setFieldValue("players", newPlayers);
   };
 


### PR DESCRIPTION
## 概要

Closes #158

ゲーム設定画面のプレイヤータブで、プレイヤーをゲームから削除できるようにし、並び替え操作の案内メッセージを追加しました。

## 変更内容

### 1. プレイヤーカード右上メニューに「プレイヤーを削除」を追加
- 赤色の `IconTrash` 付きメニュー項目を追加
- `deleteGamePlayer` 関数を実装。プレイヤーの**元データ（playersテーブル）は削除せず**、このゲームの参加者（`games.players`）から外す挙動。あわせて該当ゲーム・該当プレイヤーの操作ログ（`logs`）も削除します
- カードから削除した際に、プレイヤー選択ドロワー内の `CompactPlayerTable` のチェック状態も同期するよう、`gamePlayers` の変化を監視する処理を追加

### 2. プレイヤータブ上部にドラッグ案内メッセージを表示
- プレイヤーが1人以上いる場合に、グリップアイコンをインライン配置した次の案内文を表示
  > プレイヤー左上の[アイコン]アイコンを持ってドラッグすると順番を変えられます。

## 確認

- `tsc --noEmit` 型エラーなし
- lint / format / stylelint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)