### PR TITLE
feat: トップページの改善（最近のゲーム・メニュー導線・機能紹介の調整）

### DIFF
--- a/src/app/(default)/_components/Features/Features.module.css
+++ b/src/app/(default)/_components/Features/Features.module.css
@@ -1,5 +1,8 @@
 .features {
   z-index: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
   padding: 1rem 1rem 0;
   background-image:
     linear-gradient(0deg, transparent calc(100% - 1px), #f0f0f0 calc(100% - 1px)),
@@ -12,51 +15,46 @@
       linear-gradient(0deg, transparent calc(100% - 1px), #2d3748 calc(100% - 1px)),
       linear-gradient(90deg, transparent calc(100% - 1px), #2d3748 calc(100% - 1px));
   }
+
+  @media (width >= 62em) {
+    gap: 0;
+  }
 }
 
 .each_feature {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  align-items: flex-start;
   padding: 0.5rem;
   font-size: 1.5rem;
   line-height: 1.5rem;
-
-  &:nth-child(odd) {
-    align-items: flex-start;
-
-    .feature_decoration {
-      left: -5px;
-
-      @media (width >= 62em) {
-        left: -30px;
-      }
-    }
-  }
-
-  &:nth-child(even) {
-    align-items: flex-end;
-
-    .feature_decoration {
-      right: -5px;
-
-      @media (width >= 62em) {
-        right: -30px;
-      }
-    }
-  }
 
   @media (width >= 62em) {
     gap: 1rem;
     padding: 2rem;
     font-size: 2rem;
     line-height: 2rem;
+
+    &:nth-child(odd) .feature_decoration {
+      left: -30px;
+    }
+
+    &:nth-child(even) {
+      align-items: flex-end;
+
+      .feature_decoration {
+        right: -30px;
+        left: auto;
+      }
+    }
   }
 }
 
 .feature_decoration {
   position: absolute;
   top: -5px;
+  left: -5px;
   z-index: 0;
   width: 90px;
   height: 90px;
@@ -83,5 +81,19 @@
 
 .feature_image {
   z-index: 10;
-  width: 75%;
+  width: 100%;
+  padding: 0.75rem;
+  background-color: var(--mantine-color-white);
+  border: 1px solid var(--mantine-color-gray-3);
+  border-radius: var(--mantine-radius-md);
+  box-shadow: var(--mantine-shadow-md);
+
+  @mixin dark {
+    background-color: var(--mantine-color-dark-6);
+    border-color: var(--mantine-color-dark-4);
+  }
+
+  @media (width >= 62em) {
+    width: 75%;
+  }
 }

--- a/src/app/(default)/_components/Hero/Hero.module.css
+++ b/src/app/(default)/_components/Hero/Hero.module.css
@@ -3,7 +3,7 @@
   margin: -1rem -1rem 11.5rem;
 
   @media (width >= 62em) {
-    margin-bottom: 2rem;
+    margin-bottom: 3rem;
   }
 }
 

--- a/src/app/(default)/_components/Hero/QuickStart/QuickStart.module.css
+++ b/src/app/(default)/_components/Hero/QuickStart/QuickStart.module.css
@@ -37,8 +37,19 @@
 }
 
 .rule_select {
+  display: none;
+
   @media (width >= 62em) {
+    display: block;
     flex: 1 1 auto;
+  }
+}
+
+.rule_native_select {
+  display: block;
+
+  @media (width >= 62em) {
+    display: none;
   }
 }
 

--- a/src/app/(default)/_components/Hero/QuickStart/QuickStart.tsx
+++ b/src/app/(default)/_components/Hero/QuickStart/QuickStart.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { Anchor, Box, Button, NumberInput, Select } from "@mantine/core";
+import { Anchor, Box, Button, NativeSelect, NumberInput, Select } from "@mantine/core";
 import { IconArrowRight, IconSettings } from "@tabler/icons-react";
 import { z } from "zod";
 
@@ -37,6 +37,15 @@ const QuickStart = () => {
 
   const isPlayerCountFixed = typeof FIXED_PLAYER_COUNTS[rule] === "number";
 
+  /** 選択された形式を検証して state を更新し、固定人数形式なら人数も同期する */
+  const applyRule = (value: string | null) => {
+    const result = RuleSchema.safeParse(value);
+    if (!result.success) return;
+    setRule(result.data);
+    const fixed = FIXED_PLAYER_COUNTS[result.data];
+    if (typeof fixed === "number") setPlayers(fixed);
+  };
+
   return (
     <Box className={classes.card}>
       <Box className={classes.card_title}>得点表示を作る</Box>
@@ -48,13 +57,15 @@ const QuickStart = () => {
           label="形式"
           radius="md"
           value={rule}
-          onChange={(value) => {
-            const result = RuleSchema.safeParse(value);
-            if (!result.success) return;
-            setRule(result.data);
-            const fixed = FIXED_PLAYER_COUNTS[result.data];
-            if (typeof fixed === "number") setPlayers(fixed);
-          }}
+          onChange={(value) => applyRule(value)}
+        />
+        <NativeSelect
+          className={classes.rule_native_select}
+          data={ruleOptions}
+          label="形式"
+          radius="md"
+          value={rule}
+          onChange={(event) => applyRule(event.currentTarget.value)}
         />
         <NumberInput
           className={classes.player_input}

--- a/src/app/(default)/_components/QuickLinks/QuickLinks.module.css
+++ b/src/app/(default)/_components/QuickLinks/QuickLinks.module.css
@@ -1,0 +1,41 @@
+.quick_links {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+  margin-top: 2rem;
+
+  @media (width >= 62em) {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.quick_link_card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: inherit;
+  text-decoration: none;
+  transition:
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+
+  &:hover {
+    box-shadow: var(--mantine-shadow-md);
+    transform: translateY(-2px);
+  }
+}
+
+.quick_link_title {
+  font-size: 1.125rem;
+}
+
+.quick_link_description {
+  font-size: 0.875rem;
+  color: var(--mantine-color-dimmed);
+}
+
+.quick_link_footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: auto;
+}

--- a/src/app/(default)/_components/QuickLinks/QuickLinks.module.css
+++ b/src/app/(default)/_components/QuickLinks/QuickLinks.module.css
@@ -1,8 +1,13 @@
 .quick_links {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card_grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 1rem;
-  margin-top: 2rem;
 
   @media (width >= 62em) {
     grid-template-columns: 1fr 1fr;
@@ -11,8 +16,9 @@
 
 .quick_link_card {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
   color: inherit;
   text-decoration: none;
   transition:
@@ -25,17 +31,21 @@
   }
 }
 
+.quick_link_label {
+  align-items: center;
+}
+
+.quick_link_label svg {
+  display: block;
+}
+
 .quick_link_title {
-  font-size: 1.125rem;
+  padding: 0;
+  font-size: 1.5rem;
 }
 
-.quick_link_description {
-  font-size: 0.875rem;
+.quick_link_chevron {
+  display: block;
+  flex-shrink: 0;
   color: var(--mantine-color-dimmed);
-}
-
-.quick_link_footer {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: auto;
 }

--- a/src/app/(default)/_components/QuickLinks/QuickLinks.tsx
+++ b/src/app/(default)/_components/QuickLinks/QuickLinks.tsx
@@ -1,0 +1,55 @@
+import { Box, Button, Card, Text, Title } from "@mantine/core";
+import { IconChevronRight } from "@tabler/icons-react";
+
+import ClientLink from "@/components/ClientLink/ClientLink";
+
+import classes from "./QuickLinks.module.css";
+
+type QuickLink = {
+  href: string;
+  title: string;
+  description: string;
+};
+
+/** プレイヤー管理・問題管理ページへ誘導するカード群 */
+const QuickLinks = () => {
+  const links: QuickLink[] = [
+    {
+      href: "/players",
+      title: "プレイヤー管理",
+      description: "ゲームで使用するプレイヤーを登録・編集できます。",
+    },
+    {
+      href: "/quizes",
+      title: "問題管理",
+      description: "問題文を読み込んで得点表示画面に表示できます。",
+    },
+  ];
+
+  return (
+    <Box className={classes.quick_links}>
+      {links.map((link) => (
+        <Card
+          className={classes.quick_link_card}
+          component={ClientLink}
+          href={link.href}
+          key={link.href}
+          shadow="xs"
+          withBorder
+        >
+          <Title className={classes.quick_link_title} order={3}>
+            {link.title}
+          </Title>
+          <Text className={classes.quick_link_description}>{link.description}</Text>
+          <Box className={classes.quick_link_footer}>
+            <Button component="span" rightSection={<IconChevronRight />} size="sm">
+              開く
+            </Button>
+          </Box>
+        </Card>
+      ))}
+    </Box>
+  );
+};
+
+export default QuickLinks;

--- a/src/app/(default)/_components/QuickLinks/QuickLinks.tsx
+++ b/src/app/(default)/_components/QuickLinks/QuickLinks.tsx
@@ -1,5 +1,15 @@
-import { Box, Button, Card, Text, Title } from "@mantine/core";
-import { IconChevronRight } from "@tabler/icons-react";
+import { Box, Card, Group, Title } from "@mantine/core";
+import {
+  IconChevronRight,
+  IconExternalLink,
+  IconFileText,
+  IconHelp,
+  IconInfoCircle,
+  IconList,
+  IconListDetails,
+  IconSettings,
+  IconUsers,
+} from "@tabler/icons-react";
 
 import ClientLink from "@/components/ClientLink/ClientLink";
 
@@ -8,46 +18,58 @@ import classes from "./QuickLinks.module.css";
 type QuickLink = {
   href: string;
   title: string;
-  description: string;
+  icon: React.ReactNode;
+  external?: boolean;
 };
 
-/** プレイヤー管理・問題管理ページへ誘導するカード群 */
+/** サイドバーの各ページへ誘導するカード群 */
 const QuickLinks = () => {
   const links: QuickLink[] = [
+    { href: "/rules", title: "形式一覧", icon: <IconListDetails /> },
+    { href: "/games", title: "作成したゲーム", icon: <IconList /> },
+    { href: "/players", title: "プレイヤー管理", icon: <IconUsers /> },
+    { href: "/quizes", title: "問題管理", icon: <IconFileText /> },
+    { href: "/option", title: "アプリ設定", icon: <IconSettings /> },
+    { href: "/docs", title: "アプリ情報", icon: <IconInfoCircle /> },
     {
-      href: "/players",
-      title: "プレイヤー管理",
-      description: "ゲームで使用するプレイヤーを登録・編集できます。",
-    },
-    {
-      href: "/quizes",
-      title: "問題管理",
-      description: "問題文を読み込んで得点表示画面に表示できます。",
+      href: "https://docs.score-watcher.com/",
+      title: "使い方を見る",
+      icon: <IconHelp />,
+      external: true,
     },
   ];
 
   return (
     <Box className={classes.quick_links}>
-      {links.map((link) => (
-        <Card
-          className={classes.quick_link_card}
-          component={ClientLink}
-          href={link.href}
-          key={link.href}
-          shadow="xs"
-          withBorder
-        >
-          <Title className={classes.quick_link_title} order={3}>
-            {link.title}
-          </Title>
-          <Text className={classes.quick_link_description}>{link.description}</Text>
-          <Box className={classes.quick_link_footer}>
-            <Button component="span" rightSection={<IconChevronRight />} size="sm">
-              開く
-            </Button>
-          </Box>
-        </Card>
-      ))}
+      <Title order={2} style={{ padding: 0 }}>
+        メニュー
+      </Title>
+      <Box className={classes.card_grid}>
+        {links.map((link) => (
+          <Card
+            className={classes.quick_link_card}
+            component={ClientLink}
+            href={link.href}
+            key={link.href}
+            rel={link.external ? "noopener noreferrer" : undefined}
+            shadow="xs"
+            target={link.external ? "_blank" : undefined}
+            withBorder
+          >
+            <Group className={classes.quick_link_label} gap="sm" wrap="nowrap">
+              {link.icon}
+              <Title className={classes.quick_link_title} order={3}>
+                {link.title}
+              </Title>
+            </Group>
+            {link.external ? (
+              <IconExternalLink className={classes.quick_link_chevron} />
+            ) : (
+              <IconChevronRight className={classes.quick_link_chevron} />
+            )}
+          </Card>
+        ))}
+      </Box>
     </Box>
   );
 };

--- a/src/app/(default)/_components/RecentGames/RecentGames.module.css
+++ b/src/app/(default)/_components/RecentGames/RecentGames.module.css
@@ -1,3 +1,0 @@
-.recent_games {
-  margin-bottom: 2rem;
-}

--- a/src/app/(default)/_components/RecentGames/RecentGames.module.css
+++ b/src/app/(default)/_components/RecentGames/RecentGames.module.css
@@ -1,0 +1,3 @@
+.recent_games {
+  margin-bottom: 2rem;
+}

--- a/src/app/(default)/_components/RecentGames/RecentGames.tsx
+++ b/src/app/(default)/_components/RecentGames/RecentGames.tsx
@@ -11,7 +11,6 @@ import db from "@/utils/db";
 import { parseGameList } from "@/utils/parseGameList";
 
 import GameListGrid from "../../games/_components/GameListGrid/GameListGrid";
-import classes from "./RecentGames.module.css";
 
 type Props = {
   currentProfile: string;
@@ -36,7 +35,7 @@ const RecentGames: React.FC<Props> = ({ currentProfile }) => {
   const recentGames = parseGameList(games, logs, "last_open").slice(0, RECENT_GAMES_COUNT);
 
   return (
-    <Box className={classes.recent_games}>
+    <Box>
       <Group justify="space-between" align="center" mb="md">
         <Title order={2} style={{ padding: 0 }}>
           最近のゲーム

--- a/src/app/(default)/_components/RecentGames/RecentGames.tsx
+++ b/src/app/(default)/_components/RecentGames/RecentGames.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { Box, Group, Title } from "@mantine/core";
+import { useLocalStorage } from "@mantine/hooks";
+import { IconList } from "@tabler/icons-react";
+import { useLiveQuery } from "dexie-react-hooks";
+
+import ButtonLink from "@/components/ButtonLink";
+import { CURRENT_PROFILE_STORAGE_KEY } from "@/utils/current-profile";
+import db from "@/utils/db";
+import { parseGameList } from "@/utils/parseGameList";
+
+import GameListGrid from "../../games/_components/GameListGrid/GameListGrid";
+import classes from "./RecentGames.module.css";
+
+type Props = {
+  currentProfile: string;
+};
+
+const RECENT_GAMES_COUNT = 3;
+
+/** トップページで作成済みゲームの先頭数件を表示するセクション。ゲームが無ければ何も描画しない */
+const RecentGames: React.FC<Props> = ({ currentProfile }) => {
+  const [storedCurrentProfile] = useLocalStorage({
+    key: CURRENT_PROFILE_STORAGE_KEY,
+    defaultValue: currentProfile,
+  });
+  const games = useLiveQuery(
+    () => db(storedCurrentProfile).games.orderBy("last_open").reverse().toArray(),
+    [storedCurrentProfile]
+  );
+  const logs = useLiveQuery(() => db(storedCurrentProfile).logs.toArray(), [storedCurrentProfile]);
+
+  if (games === undefined || games.length === 0) return null;
+
+  const recentGames = parseGameList(games, logs, "last_open").slice(0, RECENT_GAMES_COUNT);
+
+  return (
+    <Box className={classes.recent_games}>
+      <Group justify="space-between" align="center" mb="md">
+        <Title order={2} style={{ padding: 0 }}>
+          最近のゲーム
+        </Title>
+        <ButtonLink href="/games" leftSection={<IconList />} size="sm" variant="subtle">
+          すべて見る
+        </ButtonLink>
+      </Group>
+      <GameListGrid gameList={recentGames} />
+    </Box>
+  );
+};
+
+export default RecentGames;

--- a/src/app/(default)/_components/Term.tsx
+++ b/src/app/(default)/_components/Term.tsx
@@ -6,7 +6,7 @@ import Link from "@/components/Link";
 
 const Term: React.FC = () => {
   return (
-    <Box mt="lg">
+    <Box>
       <Title order={2}>ご利用にあたって</Title>
       <List>
         <List.Item>

--- a/src/app/(default)/games/_components/GameList/GameList.tsx
+++ b/src/app/(default)/games/_components/GameList/GameList.tsx
@@ -6,10 +6,9 @@ import { Group, NativeSelect, SegmentedControl, Title } from "@mantine/core";
 import { useLocalStorage } from "@mantine/hooks";
 import { useLiveQuery } from "dexie-react-hooks";
 
-import Link from "@/components/Link";
 import { CURRENT_PROFILE_STORAGE_KEY } from "@/utils/current-profile";
 import db from "@/utils/db";
-import { getRuleStringByType } from "@/utils/rules";
+import { parseGameList } from "@/utils/parseGameList";
 
 import GameListGrid from "../GameListGrid/GameListGrid";
 import GameListTable from "../GameListTable/GameListTable";
@@ -31,30 +30,7 @@ const GameList: React.FC<Props> = ({ currentProfile }) => {
   const [orderType, setOrderType] = useState<"last_open" | "name">("last_open");
   const [displayMode, setDisplayMode] = useState<"grid" | "table">("grid");
 
-  const parsedGameList = (games || [])
-    .sort((prev, cur) => {
-      if (orderType === "last_open") {
-        if (prev.last_open > cur.last_open) return -1;
-        if (prev.last_open < cur.last_open) return 1;
-        return 0;
-      } else {
-        if (prev.name < cur.name) return -1;
-        if (prev.name > cur.name) return 1;
-        return 0;
-      }
-    })
-    .map((game) => {
-      const eachGameLogs = (logs || []).filter((log) => log.game_id === game.id);
-      const gameState = eachGameLogs.length === 0 ? "設定中" : `${eachGameLogs.length}問目`;
-      return {
-        id: game.id,
-        name: game.name,
-        type: getRuleStringByType(game),
-        player_count: game.players.length,
-        state: gameState,
-        last_open: game.last_open,
-      };
-    });
+  const parsedGameList = parseGameList(games, logs, orderType);
 
   return (
     <>
@@ -73,13 +49,7 @@ const GameList: React.FC<Props> = ({ currentProfile }) => {
           <option value="name">ゲーム名順</option>
         </NativeSelect>
       </Group>
-      {parsedGameList.length === 0 ? (
-        <p>
-          作成済みのゲームはありません。
-          <Link href="/rules">形式一覧</Link>
-          ページから新しいゲームを作ることが出来ます。
-        </p>
-      ) : displayMode === "grid" ? (
+      {displayMode === "grid" ? (
         <GameListGrid gameList={parsedGameList} />
       ) : (
         <GameListTable gameList={parsedGameList} />

--- a/src/app/(default)/games/_components/GameListGrid/GameListGrid.module.css
+++ b/src/app/(default)/games/_components/GameListGrid/GameListGrid.module.css
@@ -4,6 +4,19 @@
   gap: 1rem;
 }
 
+.game_card {
+  color: inherit;
+  text-decoration: none;
+  transition:
+    box-shadow 0.15s ease,
+    transform 0.15s ease;
+
+  &:hover {
+    box-shadow: var(--mantine-shadow-md);
+    transform: translateY(-2px);
+  }
+}
+
 .game_name {
   padding: 0.5rem 1rem;
   overflow-x: scroll;

--- a/src/app/(default)/games/_components/GameListGrid/GameListGrid.tsx
+++ b/src/app/(default)/games/_components/GameListGrid/GameListGrid.tsx
@@ -1,23 +1,18 @@
 "use client";
 
-import { Box, Card, Flex, List } from "@mantine/core";
-import { IconAdjustmentsHorizontal } from "@tabler/icons-react";
+import { Box, Button, Card, Flex, List } from "@mantine/core";
+import { IconChevronRight } from "@tabler/icons-react";
 import { cdate } from "cdate";
 
-import ButtonLink from "@/components/ButtonLink";
+import ClientLink from "@/components/ClientLink/ClientLink";
 import Link from "@/components/Link";
 
 import classes from "./GameListGrid.module.css";
 
+import type { ParsedGameListItem } from "@/utils/types";
+
 type Props = {
-  gameList: {
-    id: string;
-    name: string;
-    type: string;
-    player_count: number;
-    state: string;
-    last_open: string;
-  }[];
+  gameList: ParsedGameListItem[];
 };
 
 const GameListGrid: React.FC<Props> = ({ gameList }) => {
@@ -32,7 +27,15 @@ const GameListGrid: React.FC<Props> = ({ gameList }) => {
       ) : (
         <Box className={classes.game_list_grid}>
           {gameList.map((game) => (
-            <Card shadow="xs" key={game.id} title={game.name} withBorder>
+            <Card
+              className={classes.game_card}
+              component={ClientLink}
+              href={`/games/${game.id}/config`}
+              key={game.id}
+              shadow="xs"
+              title={game.name}
+              withBorder
+            >
               <Card.Section className={classes.game_name} withBorder inheritPadding>
                 {game.name}
               </Card.Section>
@@ -46,13 +49,9 @@ const GameListGrid: React.FC<Props> = ({ gameList }) => {
               </Card.Section>
               <Flex className={classes.game_footer}>
                 <Box>{cdate(game.last_open).format("MM/DD HH:mm")}</Box>
-                <ButtonLink
-                  href={`/games/${game.id}/config`}
-                  leftSection={<IconAdjustmentsHorizontal />}
-                  size="sm"
-                >
+                <Button component="span" rightSection={<IconChevronRight />} size="sm">
                   開く
-                </ButtonLink>
+                </Button>
               </Flex>
             </Card>
           ))}

--- a/src/app/(default)/games/_components/GameListTable/GameListTable.tsx
+++ b/src/app/(default)/games/_components/GameListTable/GameListTable.tsx
@@ -7,15 +7,10 @@ import { cdate } from "cdate";
 import ButtonLink from "@/components/ButtonLink";
 import Link from "@/components/Link";
 
+import type { ParsedGameListItem } from "@/utils/types";
+
 type Props = {
-  gameList: {
-    id: string;
-    name: string;
-    type: string;
-    player_count: number;
-    state: string;
-    last_open: string;
-  }[];
+  gameList: ParsedGameListItem[];
 };
 
 const GameListTable: React.FC<Props> = ({ gameList }) => {

--- a/src/app/(default)/page.module.css
+++ b/src/app/(default)/page.module.css
@@ -1,0 +1,5 @@
+.home_sections {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}

--- a/src/app/(default)/page.tsx
+++ b/src/app/(default)/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from "next";
 
+import { DEFAULT_CURRENT_PROFILE } from "@/utils/current-profile";
+
 import Features from "./_components/Features/Features";
 import Hero from "./_components/Hero/Hero";
+import QuickLinks from "./_components/QuickLinks/QuickLinks";
+import RecentGames from "./_components/RecentGames/RecentGames";
 import Term from "./_components/Term";
 
 export const metadata: Metadata = {
@@ -14,7 +18,9 @@ const HomePage = () => {
   return (
     <>
       <Hero />
+      <RecentGames currentProfile={DEFAULT_CURRENT_PROFILE} />
       <Features />
+      <QuickLinks />
       <Term />
     </>
   );

--- a/src/app/(default)/page.tsx
+++ b/src/app/(default)/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 
+import { Box } from "@mantine/core";
+
 import { DEFAULT_CURRENT_PROFILE } from "@/utils/current-profile";
 
 import Features from "./_components/Features/Features";
@@ -7,6 +9,7 @@ import Hero from "./_components/Hero/Hero";
 import QuickLinks from "./_components/QuickLinks/QuickLinks";
 import RecentGames from "./_components/RecentGames/RecentGames";
 import Term from "./_components/Term";
+import classes from "./page.module.css";
 
 export const metadata: Metadata = {
   alternates: {
@@ -18,10 +21,12 @@ const HomePage = () => {
   return (
     <>
       <Hero />
-      <RecentGames currentProfile={DEFAULT_CURRENT_PROFILE} />
-      <Features />
-      <QuickLinks />
-      <Term />
+      <Box className={classes.home_sections}>
+        <RecentGames currentProfile={DEFAULT_CURRENT_PROFILE} />
+        <Features />
+        <QuickLinks />
+        <Term />
+      </Box>
     </>
   );
 };

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -1,0 +1,6 @@
+.external_icon {
+  width: 1em;
+  height: 1em;
+  margin-left: 0.25em;
+  vertical-align: -0.15em;
+}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -4,6 +4,8 @@ import { Anchor } from "@mantine/core";
 import { IconExternalLink } from "@tabler/icons-react";
 import { default as NextLink } from "next/link";
 
+import classes from "./Link.module.css";
+
 type Props = {
   children: React.ReactNode;
   href: string;
@@ -20,7 +22,7 @@ const Link: React.FC<Props> = (props) => {
       target={href.startsWith("http") ? "_blank" : "_self"}
     >
       {children}
-      {href.startsWith("http") && <IconExternalLink />}
+      {href.startsWith("http") && <IconExternalLink className={classes.external_icon} />}
     </Anchor>
   );
 };

--- a/src/utils/parseGameList.ts
+++ b/src/utils/parseGameList.ts
@@ -1,0 +1,38 @@
+import { getRuleStringByType } from "@/utils/rules";
+
+import type { GamePropsUnion, LogDBProps, ParsedGameListItem } from "@/utils/types";
+
+/**
+ * ゲームとログの配列を一覧表示用に整形する。
+ * orderType に応じて最終閲覧順またはゲーム名順で並べ替え、各ゲームの進行状況を算出する。
+ */
+export const parseGameList = (
+  games: GamePropsUnion[] | undefined,
+  logs: LogDBProps[] | undefined,
+  orderType: "last_open" | "name"
+): ParsedGameListItem[] => {
+  return [...(games ?? [])]
+    .sort((prev, cur) => {
+      if (orderType === "last_open") {
+        if (prev.last_open > cur.last_open) return -1;
+        if (prev.last_open < cur.last_open) return 1;
+        return 0;
+      } else {
+        if (prev.name < cur.name) return -1;
+        if (prev.name > cur.name) return 1;
+        return 0;
+      }
+    })
+    .map((game) => {
+      const eachGameLogs = (logs ?? []).filter((log) => log.game_id === game.id);
+      const gameState = eachGameLogs.length === 0 ? "設定中" : `${eachGameLogs.length}問目`;
+      return {
+        id: game.id,
+        name: game.name,
+        type: getRuleStringByType(game),
+        player_count: game.players.length,
+        state: gameState,
+        last_open: game.last_open,
+      };
+    });
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -78,6 +78,16 @@ export type AllGameProps = {
 
 export type GamePropsUnion = AllGameProps[RuleNames];
 
+/** ゲーム一覧表示用に整形したゲーム1件分のデータ */
+export type ParsedGameListItem = {
+  id: string;
+  name: string;
+  type: string;
+  player_count: number;
+  state: string;
+  last_open: string;
+};
+
 export type PlayerDBProps = {
   id: string;
   name: string;

--- a/tests/game.spec.ts
+++ b/tests/game.spec.ts
@@ -37,7 +37,8 @@ test.describe("得点表示", () => {
   });
 
   test("形式一覧ページに移動できる", async () => {
-    await page.getByRole("link", { name: "形式一覧" }).click();
+    // トップページの QuickLinks にも同名リンクがあるため、サイドバー(banner)に限定する
+    await page.getByRole("banner").getByRole("link", { name: "形式一覧" }).click();
     await expect(page).toHaveTitle(/形式一覧/);
   });
 
@@ -76,11 +77,13 @@ test.describe("得点表示", () => {
     if (isMobile) {
       await page.getByRole("banner").getByRole("button").first().click();
     }
-    await page.getByRole("link", { name: "作成したゲーム" }).click();
+    // トップページの QuickLinks にも同名リンクがあるため、サイドバー(banner)に限定する
+    await page.getByRole("banner").getByRole("link", { name: "作成したゲーム" }).click();
     await expect(page).toHaveTitle(/作成したゲーム/);
     const gameEl = page.getByTitle("スコア計算").first();
     await expect(gameEl).toContainText("5人");
-    await gameEl.getByRole("link", { name: "開く" }).click();
+    // ゲームカード全体がリンクになっているため、カードをクリックして設定ページへ遷移する
+    await gameEl.click();
   });
 
   test("得点表示のページに移動できる", async () => {
@@ -154,7 +157,8 @@ test.describe("誤答数の記号表示", () => {
     if (isMobile) {
       await page.getByRole("banner").getByRole("button").first().click();
     }
-    await page.getByRole("link", { name: "形式一覧" }).click();
+    // トップページの QuickLinks にも同名リンクがあるため、サイドバー(banner)に限定する
+    await page.getByRole("banner").getByRole("link", { name: "形式一覧" }).click();
     await expect(page).toHaveTitle(/形式一覧/);
     // 「N○M✕」(nomx)と「連答つきN○M✕」(nomx-ad)を区別するため厳密一致で絞り込む
     const card = page


### PR DESCRIPTION
## 概要

トップページを刷新し、ユーザーが各機能へアクセスしやすい導線を整備しました。

Close #159

## 変更内容

### 最近のゲームセクションの追加
- `RecentGames` コンポーネントを新設し、作成済みゲームの先頭3件をトップページに表示
- ゲームが無い場合は何も描画しない
- 一覧整形ロジックを `parseGameList` として切り出し、`GameList` と共通化

### メニュー導線の刷新
- `QuickLinks` コンポーネントを新設し、各管理ページ・外部ドキュメントへのカード型導線を追加
- 内部リンクには `IconChevronRight`、外部リンクには `IconExternalLink` を表示

### ゲームカードの改善
- `GameListGrid` のカード全体をリンク化（`ClientLink` を `component` に指定）、ホバー時のシャドウ・浮き上がりを追加
- `gameList` の型を `ParsedGameListItem` として `types.ts` に定義し、`GameListGrid` / `GameListTable` で共通利用

### 機能紹介（Features）の調整
- セクション間隔を flex gap に統一
- 機能画像にボーダー・シャドウ・パディングを追加し、ダークモードにも対応

### QuickStart のモバイル対応
- モバイルでは `NativeSelect`、デスクトップでは `Select` を表示するよう切り替え
- 形式選択ロジックを `applyRule` に共通化

### その他
- 外部リンクアイコン（`Link`）の垂直位置とテキストとの余白を CSS Modules で調整
- トップページのセクション間隔を flex gap に統一

## テスト

- `npx tsc --noEmit` / `pnpm run lint` 実行済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)