### PR TITLE
feat: QuickStartの形式ラベルにデフォルト数値を表示 (#170)

### DIFF
--- a/src/app/(default)/_components/QuickStart/QuickStart.tsx
+++ b/src/app/(default)/_components/QuickStart/QuickStart.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 import { z } from "zod";
 
 import { MAX_PLAYER_COUNT } from "@/utils/functions";
-import { rules } from "@/utils/rules";
+import { getRuleStringByType, rules } from "@/utils/rules";
 
 import classes from "./QuickStart.module.css";
 
@@ -32,7 +32,7 @@ const QuickStart = () => {
 
   const ruleOptions = Object.values(rules).map((r) => ({
     value: r.rule,
-    label: r.name,
+    label: r.rule === "normal" ? r.name : getRuleStringByType(r),
   }));
 
   const isPlayerCountFixed = typeof FIXED_PLAYER_COUNTS[rule] === "number";

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -204,18 +204,20 @@ export const rules = {
   },
 } as const satisfies RuleProps;
 
-export const getRuleStringByType = (game: GamePropsUnion): string => {
+type RuleStringInput = Pick<GamePropsUnion, "rule" | "win_point" | "lose_point">;
+
+export const getRuleStringByType = (game: RuleStringInput): string => {
   switch (game.rule) {
     case "normal":
       return "カウンター";
     case "nomx":
-      return `${game.win_point}o${game.lose_point}x`;
+      return `${game.win_point}○${game.lose_point}✕`;
     case "nomx-ad":
-      return `連答つき${game.win_point}o${game.lose_point}x`;
+      return `連答つき${game.win_point}○${game.lose_point}✕`;
     case "ny":
       return "NewYork";
     case "nomr":
-      return `${game.win_point}○N休`;
+      return `${game.win_point}○${game.lose_point}休`;
     case "nbyn":
       return `${game.win_point}by${game.win_point}`;
     case "nupdown":


### PR DESCRIPTION
## 概要

Closes #170

QuickStart（トップページの「得点表示を作る」カード）の形式セレクトで、`N○M✕` などのプレースホルダ表記をデフォルト数値入りの表記（`7○3✕`）に変更しました。これにより「`N○M✕` を選んだのにそのまま開始すると `7o3x` になる」という食い違いを解消します。

## 変更内容

### `src/utils/rules.ts` — `getRuleStringByType` の修正
- 引数型を `Pick<GamePropsUnion, "rule" | "win_point" | "lose_point">` に絞り、`rules` 定義からも呼べるように
- 既存の癖を修正:
  - `nomx`: `7o3x` → `7○3✕`（全角化）
  - `nomx-ad`: `連答つき7o3x` → `連答つき7○3✕`
  - `nomr`: `7○N休` → `7○3休`（`N` が残るバグを修正）

### `QuickStart.tsx` — ラベル生成の変更
- `getRuleStringByType` を再利用してデフォルト数値入り文字列を表示（ロジックの二重化を回避）
- `normal` のみ `name`「スコア計算」を表示
- `Select` / `NativeSelect` の両方に反映

## 影響範囲
- ゲーム中のボード表示・ゲーム一覧の形式文字列も `7○3✕`・`7○3休` に統一され、QuickStart の選択肢と一致します。

## 検証
- [x] `npx tsc --noEmit && pnpm run lint:fix` エラーなし
- [x] `pnpm run vitest` 81件すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)