### PR TITLE
fix: useLiveQueryの依存配列にcurrentProfileを追加しプロファイル切替後のデータ表示を修正

### DIFF
--- a/src/app/(board)/games/[game_id]/board/_components/AQLPlayer/AQLPlayer.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/AQLPlayer/AQLPlayer.tsx
@@ -34,7 +34,10 @@ const AQLPlayer: React.FC<Props> = ({
 }) => {
   const numberSign = useNumberSign();
   const computedColorScheme = useComputedColorScheme("light");
-  const game = useLiveQuery(() => db(currentProfile).games.get(game_id as string));
+  const game = useLiveQuery(
+    () => db(currentProfile).games.get(game_id as string),
+    [currentProfile, game_id]
+  );
   const [editableState, setEditableState] = useState<States>("playing");
 
   useEffect(() => {

--- a/src/app/(board)/games/[game_id]/board/_components/Player/Player.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/Player/Player.tsx
@@ -27,7 +27,10 @@ type Props = {
 
 const Player: React.FC<Props> = ({ game_id, player, index, score, currentProfile }) => {
   const computedColorScheme = useComputedColorScheme("light");
-  const game = useLiveQuery(() => db(currentProfile).games.get(game_id as string));
+  const game = useLiveQuery(
+    () => db(currentProfile).games.get(game_id as string),
+    [currentProfile, game_id]
+  );
   const [editableState, setEditableState] = useState<States>("playing");
 
   const [reversePlayerInfo] = useLocalStorage({

--- a/src/app/(board)/games/[game_id]/board/_components/PlayerScore/PlayerScore.tsx
+++ b/src/app/(board)/games/[game_id]/board/_components/PlayerScore/PlayerScore.tsx
@@ -23,7 +23,7 @@ const PlayerScore: React.FC<Props> = ({ game, player, currentProfile }) => {
   const numberSign = useNumberSign();
   const logs = useLiveQuery(
     () => db(currentProfile).logs.where({ game_id: game.id, available: 1 }).sortBy("timestamp"),
-    []
+    [currentProfile, game.id]
   );
 
   const props = {

--- a/src/app/(default)/games/[game_id]/config/_components/ConfigInput.tsx
+++ b/src/app/(default)/games/[game_id]/config/_components/ConfigInput.tsx
@@ -32,7 +32,10 @@ const ConfigInput: React.FC<Props> = ({
 }) => {
   const innerId = useId();
   const { game_id } = useParams();
-  const game = useLiveQuery(() => db(currentProfile).games.get(game_id as string));
+  const game = useLiveQuery(
+    () => db(currentProfile).games.get(game_id as string),
+    [currentProfile, game_id]
+  );
   const [inputText, setInputText] = useState<string>("");
   const debouncedInputText = useDebouncedValue(inputText, 500);
 

--- a/src/app/(default)/games/[game_id]/config/other/_components/OtherConfig.tsx
+++ b/src/app/(default)/games/[game_id]/config/other/_components/OtherConfig.tsx
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const OtherConfig: React.FC<Props> = ({ game, currentProfile }) => {
-  const quizes = useLiveQuery(() => db(currentProfile).quizes.toArray(), []);
+  const quizes = useLiveQuery(() => db(currentProfile).quizes.toArray(), [currentProfile]);
   const quizsetList = Array.from(new Set(quizes?.map((quiz) => quiz.set_name)));
 
   return (

--- a/src/app/(default)/games/[game_id]/config/player/_components/CompactPlayerTable.tsx
+++ b/src/app/(default)/games/[game_id]/config/player/_components/CompactPlayerTable.tsx
@@ -47,7 +47,7 @@ const CompactPlayerTable: React.FC<Props> = ({
   currentProfile,
   form,
 }) => {
-  const logs = useLiveQuery(() => db(currentProfile).logs.toArray(), []);
+  const logs = useLiveQuery(() => db(currentProfile).logs.toArray(), [currentProfile]);
 
   const gamePlayerIds = gamePlayers.map((gamePlayer) => gamePlayer.id);
   const [rowSelection, setRowSelection] = useState<{ [key: number]: boolean }>({});

--- a/src/app/(default)/games/[game_id]/config/player/_components/SelectPlayerFromExistingGame.tsx
+++ b/src/app/(default)/games/[game_id]/config/player/_components/SelectPlayerFromExistingGame.tsx
@@ -26,8 +26,8 @@ type Props = {
 };
 
 const SelectPlayerFromExistingGame: React.FC<Props> = ({ game_id, currentProfile, form }) => {
-  const games = useLiveQuery(() => db(currentProfile).games.toArray(), []);
-  const logs = useLiveQuery(() => db(currentProfile).logs.toArray(), []);
+  const games = useLiveQuery(() => db(currentProfile).games.toArray(), [currentProfile]);
+  const logs = useLiveQuery(() => db(currentProfile).logs.toArray(), [currentProfile]);
 
   if (!games) return null;
 

--- a/src/app/(default)/games/[game_id]/config/rule/_components/ConfigBooleanInput.tsx
+++ b/src/app/(default)/games/[game_id]/config/rule/_components/ConfigBooleanInput.tsx
@@ -30,7 +30,10 @@ const ConfigBooleanInput: React.FC<Props[RuleNames]> = ({
 }) => {
   const innerId = useId();
   const { game_id } = useParams();
-  const game = useLiveQuery(() => db(currentProfile).games.get(game_id as string));
+  const game = useLiveQuery(
+    () => db(currentProfile).games.get(game_id as string),
+    [currentProfile, game_id]
+  );
 
   if (!game || !game.options) return null;
 

--- a/src/app/(default)/games/[game_id]/config/rule/_components/ConfigLimit/ConfigLimit.tsx
+++ b/src/app/(default)/games/[game_id]/config/rule/_components/ConfigLimit/ConfigLimit.tsx
@@ -14,7 +14,10 @@ type Props = {
 };
 
 const ConfigLimit: React.FC<Props> = ({ rule, game_id, currentProfile }) => {
-  const game = useLiveQuery(() => db(currentProfile).games.get(game_id as string));
+  const game = useLiveQuery(
+    () => db(currentProfile).games.get(game_id as string),
+    [currentProfile, game_id]
+  );
 
   if (!game) return null;
 

--- a/src/app/(default)/games/[game_id]/config/rule/_components/ConfigNumberInput.tsx
+++ b/src/app/(default)/games/[game_id]/config/rule/_components/ConfigNumberInput.tsx
@@ -29,7 +29,10 @@ const ConfigNumberInput: React.FC<Props> = ({
 }) => {
   const id = useId();
   const { game_id } = useParams();
-  const game = useLiveQuery(() => db(currentProfile).games.get(game_id as string));
+  const game = useLiveQuery(
+    () => db(currentProfile).games.get(game_id as string),
+    [currentProfile, game_id]
+  );
 
   if (!game) return null;
 

--- a/src/app/(default)/players/_components/PlayersTable.tsx
+++ b/src/app/(default)/players/_components/PlayersTable.tsx
@@ -38,8 +38,11 @@ type Props = {
 };
 
 const PlayersTable: React.FC<Props> = ({ currentProfile }) => {
-  const games = useLiveQuery(() => db(currentProfile).games.toArray(), []);
-  const players = useLiveQuery(() => db(currentProfile).players.orderBy("name").toArray(), []);
+  const games = useLiveQuery(() => db(currentProfile).games.toArray(), [currentProfile]);
+  const players = useLiveQuery(
+    () => db(currentProfile).players.orderBy("name").toArray(),
+    [currentProfile]
+  );
   const [searchText, setSearchText] = useState<string>("");
 
   const [selectedPlayers, setSelectedPlayers] = useState({});

--- a/src/app/(default)/quizes/_components/QuizesTable/QuizesTable.tsx
+++ b/src/app/(default)/quizes/_components/QuizesTable/QuizesTable.tsx
@@ -27,7 +27,10 @@ type Props = {
 };
 
 const QuizesTable: React.FC<Props> = ({ currentProfile }) => {
-  const quizes = useLiveQuery(() => db(currentProfile).quizes.orderBy("set_name").sortBy("n"), []);
+  const quizes = useLiveQuery(
+    () => db(currentProfile).quizes.orderBy("set_name").sortBy("n"),
+    [currentProfile]
+  );
   const [searchText, setSearchText] = useState<string>("");
 
   const [selectedQuizes, setSelectedQuizes] = useState({});


### PR DESCRIPTION
## 概要

Closes #183

プロファイル切替後にプレイヤー・問題一覧が切替先プロファイルのデータを表示しない問題を修正します。

## 原因

Mantine の `useLocalStorage`（`getInitialValueInEffect: true` が既定）は初回レンダーで既定値 `score_watcher` を返し、マウント後に実際の値へ更新されます。しかし `useLiveQuery` の依存配列が `[]`（または省略）のため、クエリのクロージャが初回レンダー時の `currentProfile` で固定され、切替後も再実行されませんでした。

## 修正内容

`useLiveQuery` の依存配列に、クロージャが参照する `currentProfile`（および `game_id` / `game.id`）を追加しました。ロジックの変更はありません。

Issue 記載の2ファイルに加え、同一パターンが潜在していた箇所を含む計12ファイルを修正しています。

- Issue で報告された箇所
  - `src/app/(default)/players/_components/PlayersTable.tsx`
  - `src/app/(default)/quizes/_components/QuizesTable/QuizesTable.tsx`
- 依存配列が `[]` だった箇所
  - `OtherConfig.tsx` / `SelectPlayerFromExistingGame.tsx` / `CompactPlayerTable.tsx` / `PlayerScore.tsx`
- 依存配列が省略されていた箇所
  - `ConfigInput.tsx` / `ConfigNumberInput.tsx` / `ConfigBooleanInput.tsx` / `ConfigLimit.tsx` / `AQLPlayer.tsx` / `Player.tsx`

## 検証

- `npx tsc --noEmit && pnpm run lint:fix` でエラーなし
- Playwright で Issue の再現手順を実行し、解消を確認
  1. `scorew_current_profile` を `docs_shooting` に設定してリロード
  2. `/players` の貼り付けタブからプレイヤーを追加 → 一覧に即座に表示（修正前は「プレイヤーが登録されていません。」のまま）
  3. リロード後も一覧に表示され、`docs_shooting` DB にデータが保存されていることを確認
  4. `/quizes` でも同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)