### PR TITLE
fix: エンドレスチャンスのラベル誤りとBackstreamの説明文を修正

### DIFF
--- a/src/app/(default)/games/[game_id]/config/rule/_components/RuleSettings.tsx
+++ b/src/app/(default)/games/[game_id]/config/rule/_components/RuleSettings.tsx
@@ -33,7 +33,7 @@ const RuleSettings: React.FC<RuleSettingsProps> = ({ game, currentProfile }) => 
       min: undefined,
     },
     "endless-chance": {
-      name: "失格誤答数",
+      name: "勝ち抜け正解数",
       max: 100,
       min: undefined,
     },

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -119,7 +119,7 @@ export const rules = {
     rule: "backstream",
     name: "Backstream",
     aliases: ["バックストリーム", "backstream"],
-    short_description: "正答数 - 誤答数が10になると勝ち抜ける形式です。",
+    short_description: "正答で+1、n回目の誤答で-nされ10ポイントを目指す形式です。",
     description: "1回の正答で+1、n回目の誤答で-nで10を目指す形式です。-10になると失格となります。",
     win_point: 10,
     lose_point: -10,


### PR DESCRIPTION
## 概要

issue #184 と issue #185 をまとめて修正します。

## 変更内容

### #184 エンドレスチャンスの勝ち抜け正解数ラベル修正

`RuleSettings.tsx` の `winPointPaires` で、エンドレスチャンスの `win_point` 入力欄のラベルが「失格誤答数」となっており、直下の `lose_point` の「失格誤答数」欄と同じラベルが2つ並んでいたため、「勝ち抜け正解数」に修正しました。

### #185 Backstream の short_description 修正

`src/utils/rules.ts` の backstream の short_description「正答数 - 誤答数が10になると勝ち抜ける形式です。」は実際の計算（正解 +1、n回目の誤答で -n の累積減点）と一致していなかったため、「正答で+1、n回目の誤答で-nされ10ポイントを目指す形式です。」に修正しました。

Closes #184
Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)